### PR TITLE
Log namespace of the configmap being worked on

### DIFF
--- a/sidecar/sidecar.py
+++ b/sidecar/sidecar.py
@@ -21,9 +21,10 @@ def watchForChanges(label, targetFolder):
     v1 = client.CoreV1Api()
     w = watch.Watch()
     for event in w.stream(v1.list_config_map_for_all_namespaces):
-        if event['object'].metadata.labels is None:
+        metadata = event['object'].metadata
+        if metadata.labels is None:
             continue
-        print("Working on configmap %s" % event['object'].metadata.name)
+        print(f'Working on configmap {metadata.namespace}/{metadata.name}')
         if label in event['object'].metadata.labels.keys():
             print("Configmap with label found")
             dataMap=event['object'].data


### PR DESCRIPTION
Also log the namespace of the configMap currently being worked on. This could be useful for debugging purposes.

```
$ kubectl -n monitoring logs -f grafana-7f9b54bd45-rzpbd -c grafana-sc-dashboard
Starting config map collector
Config for cluster api loaded...
Working on configmap kube-system/jenkins.v8
Working on configmap kube-system/metrics-server-config
Working on configmap kube-system/jenkins.v12
Working on configmap kube-system/jenkins.v3
Working on configmap monitoring/grafana
Working on configmap kube-system/jenkins.v21
```