### PR TITLE
feat: limit configmap search to current namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Example for a simple deployment can be found in `example.yaml`. Depending on the
   - type: string
 
 - `NAMESPACE`
-  - description: If specified, the sidecar will search for config-maps inside this namespace
+  - description: If specified, the sidecar will search for config-maps inside this namespace. Otherwise the namespace in which the sidecar is running will be used. It's also possible to specify `ALL` to search in all namespaces.
   - required: false
   - type: string
 

--- a/sidecar/sidecar.py
+++ b/sidecar/sidecar.py
@@ -39,12 +39,14 @@ def removeFile(folder, filename):
         print("Error: %s file not found" % completeFile)
 
 
-def watchForChanges(label, targetFolder, url, method, payload):
+def watchForChanges(label, targetFolder, url, method, payload, current):
     v1 = client.CoreV1Api()
     w = watch.Watch()
     stream = None
     namespace = os.getenv("NAMESPACE")
     if namespace is None:
+        stream = w.stream(v1.list_namespaced_config_map, namespace=current)
+    elif namespace == "ALL":
         stream = w.stream(v1.list_config_map_for_all_namespaces)
     else:
         stream = w.stream(v1.list_namespaced_config_map, namespace=namespace)
@@ -89,7 +91,8 @@ def main():
 
     config.load_incluster_config()
     print("Config for cluster api loaded...")
-    watchForChanges(label, targetFolder, url, method, payload)
+    namespace = open("/var/run/secrets/kubernetes.io/serviceaccount/namespace").read()
+    watchForChanges(label, targetFolder, url, method, payload, namespace)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This will limit the `ConfigMap` watching to the current namespace in which the sidecar is running by `default`. It still allows for a namespace to be specified or `ALL` to watch `ConfigMaps` in all namespaces. 