### PR TITLE
Allow overriding target directory with an annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ By adding additional env variables the container can send a html request to spec
 
 Example for a simple deployment can be found in `example.yaml`. Depending on the cluster setup you have to grant yourself admin rights first: `kubectl create clusterrolebinding cluster-admin-binding   --clusterrole cluster-admin   --user $(gcloud config get-value account)`
 
-One can override the default directory that files are copied into using a special annotation that looks like "k8s-sidecar-target-directory: /path/to/target/directory" the sidecar will attempt to create this directory if it does not exist.
+One can override the default directory that files are copied into using a configmap annotation defined by the environment variable "FOLDER_ANNOTATION" (if not present it will default to "k8s-sidecar-target-directory"). the sidecar will attempt to create directories defined by configmaps if they are not present. Exmaple configmap annotation:
+  k8s-sidecar-target-directory: "/path/to/target/directory"
 
 ## Configuration Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ By adding additional env variables the container can send a html request to spec
 
 Example for a simple deployment can be found in `example.yaml`. Depending on the cluster setup you have to grant yourself admin rights first: `kubectl create clusterrolebinding cluster-admin-binding   --clusterrole cluster-admin   --user $(gcloud config get-value account)`
 
+One can override the default directory that files are copied into using a special annotation that looks like "k8s-sidecar-target-directory: /path/to/target/directory" the sidecar will attempt to create this directory if it does not exist.
+
 ## Configuration Environment Variables
 
 - `LABEL` 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ By adding additional env variables the container can send a html request to spec
 
 Example for a simple deployment can be found in `example.yaml`. Depending on the cluster setup you have to grant yourself admin rights first: `kubectl create clusterrolebinding cluster-admin-binding   --clusterrole cluster-admin   --user $(gcloud config get-value account)`
 
-One can override the default directory that files are copied into using a configmap annotation defined by the environment variable "FOLDER_ANNOTATION" (if not present it will default to "k8s-sidecar-target-directory"). the sidecar will attempt to create directories defined by configmaps if they are not present. Exmaple configmap annotation:
+One can override the default directory that files are copied into using a configmap annotation defined by the environment variable "FOLDER_ANNOTATION" (if not present it will default to "k8s-sidecar-target-directory"). The sidecar will attempt to create directories defined by configmaps if they are not present. Example configmap annotation:
   k8s-sidecar-target-directory: "/path/to/target/directory"
 
 If the filename ends with `.url` suffix, the content will be processed as an URL the target file will be downloaded and used as the content file.
@@ -40,6 +40,11 @@ If the filename ends with `.url` suffix, the content will be processed as an URL
 - `FOLDER`
   - description: Folder where the files should be placed
   - required: true
+  - type: string
+
+- `FOLDER_ANNOTATION`
+  - description: The annotation the sidecar will look for in configmaps to override the destination folder for files, defaults to "k8s-sidecar-target-directory"
+  - required: false
   - type: string
 
 - `NAMESPACE`

--- a/sidecar/sidecar.py
+++ b/sidecar/sidecar.py
@@ -89,6 +89,7 @@ def watchForChanges(label, targetFolder, url, method, payload, current, folderAn
     w = watch.Watch()
     stream = None
     namespace = os.getenv("NAMESPACE")
+    destFolder = targetFolder
     if namespace is None:
         stream = w.stream(v1.list_namespaced_config_map, namespace=current)
     elif namespace == "ALL":

--- a/sidecar/sidecar.py
+++ b/sidecar/sidecar.py
@@ -16,13 +16,12 @@ def writeTextToFile(folder, filename, data):
             if e.errno != errno.EEXIST:
                 raise
 
-
     with open(folder +"/"+ filename, 'w') as f:
         f.write(data)
         f.close()
 
 
-def request(url, method, payload):
+def request(url, method, payload = None):
     r = requests.Session()
     retries = Retry(total = 5,
             connect = 5,
@@ -39,7 +38,7 @@ def request(url, method, payload):
     elif method == "POST":
         res = r.post("%s" % url, json=payload, timeout=10)
         print ("%s request sent to %s. Response: %d %s" % (method, url, res.status_code, res.reason))
-
+    return res
 
 def removeFile(folder, filename):
     completeFile = folder +"/"+filename
@@ -49,11 +48,46 @@ def removeFile(folder, filename):
         print("Error: %s file not found" % completeFile)
 
 
+def listConfigmaps(label, targetFolder, url, method, payload, current, folderAnnotation):
+    v1 = client.CoreV1Api()
+    namespace = os.getenv("NAMESPACE")
+    destFolder = targetFolder
+    if namespace is None:
+        ret = v1.list_namespaced_config_map(namespace=current)
+    elif namespace == "ALL":
+        ret = v1.list_config_map_for_all_namespaces()
+    else:
+        ret = v1.list_namespaced_config_map(namespace=namespace)
+    for cm in ret.items:
+        metadata = cm.metadata
+        if metadata.labels is None:
+            continue
+        print(f'Working on configmap {metadata.namespace}/{metadata.name}')
+        if label in cm.metadata.labels.keys():
+            print("Configmap with label found")
+            if cm.metadata.annotations is not None:
+                if folderAnnotation in cm.metadata.annotations.keys():
+                    destFolder = cm.metadata.annotations[folderAnnotation]
+
+            dataMap=cm.data
+            if dataMap is None:
+                print("Configmap does not have data.")
+                continue
+            if label in cm.metadata.labels.keys():
+                for filename in dataMap.keys():
+                    fileData = dataMap[filename]
+                    if filename.endswith(".url"):
+                        filename = filename[:-4]
+                        fileData = request(fileData, "GET").text
+                    writeTextToFile(destFolder, filename, fileData)
+                    if url is not None:
+                        request(url, method, payload)
+
+
 def watchForChanges(label, targetFolder, url, method, payload, current, folderAnnotation):
     v1 = client.CoreV1Api()
     w = watch.Watch()
     stream = None
-    destFolder = targetFolder
     namespace = os.getenv("NAMESPACE")
     if namespace is None:
         stream = w.stream(v1.list_namespaced_config_map, namespace=current)
@@ -68,13 +102,10 @@ def watchForChanges(label, targetFolder, url, method, payload, current, folderAn
         print(f'Working on configmap {metadata.namespace}/{metadata.name}')
         if label in event['object'].metadata.labels.keys():
             print("Configmap with label found")
-
-            if folderAnnotation is not None:
-                if event['object'].metadata.annotations is not None:
-                    if folderAnnotation in event['object'].metadata.annotations.keys():
-                        destFolder = event['object'].metadata.annotations[folderAnnotation]
-                        print(f'Found a folder override annotation, placing the configmap in: {destFolder}')
-
+            if event['object'].metadata.annotations is not None:
+                if folderAnnotation in event['object'].metadata.annotations.keys():
+                    destFolder = event['object'].metadata.annotations[folderAnnotation]
+                    print(f'Found a folder override annotation, placing the configmap in: {destFolder}')
             dataMap=event['object'].data
             if dataMap is None:
                 print("Configmap does not have data.")
@@ -83,10 +114,16 @@ def watchForChanges(label, targetFolder, url, method, payload, current, folderAn
             for filename in dataMap.keys():
                 print("File in configmap %s %s" % (filename, eventType))
                 if (eventType == "ADDED") or (eventType == "MODIFIED"):
-                    writeTextToFile(destFolder, filename, dataMap[filename])
+                    fileData = dataMap[filename]
+                    if filename.endswith(".url"):
+                        filename = filename[:-4]
+                        fileData = request(fileData, "GET").text
+                    writeTextToFile(destFolder, filename, fileData)
                     if url is not None:
                         request(url, method, payload)
                 else:
+                    if filename.endswith(".url"):
+                        filename = filename[:-4]
                     removeFile(destFolder, filename)
                     if url is not None:
                         request(url, method, payload)
@@ -94,11 +131,11 @@ def watchForChanges(label, targetFolder, url, method, payload, current, folderAn
 
 def main():
     print("Starting config map collector")
-    label = os.getenv('LABEL')
     folderAnnotation = os.getenv('FOLDER_ANNOTATIONS')
     if folderAnnotation is None:
         print("No folder annotation was provided, defaulting to k8s-sidecar-target-directory")
         folderAnnotation = "k8s-sidecar-target-directory"
+    label = os.getenv('LABEL')
     if label is None:
         print("Should have added LABEL as environment variable! Exit")
         return -1
@@ -113,22 +150,30 @@ def main():
 
     config.load_incluster_config()
     print("Config for cluster api loaded...")
-    with open("/var/run/secrets/kubernetes.io/serviceaccount/namespace") as f:
-        namespace = f.read()
+    namespace = open("/var/run/secrets/kubernetes.io/serviceaccount/namespace").read()
 
-    
-    while True:
-        try:
-            watchForChanges(label, targetFolder, url, method, payload, namespace, folderAnnotation)
-        except ApiException as e:
-            if "500" not in e:
-              print("ApiException when calling kubernetes: %s\n" % e)
-            else:
-              raise
-        except ProtocolError as e:
-            print("ProtocolError when calling kubernetes: %s\n" % e)
-        except:
-            raise
+    if os.getenv('SKIP_TLS_VERIFY') == 'true':
+        configuration = client.Configuration()
+        configuration.verify_ssl=False
+        configuration.debug = False
+        client.Configuration.set_default(configuration)
+
+    k8s_method = os.getenv("METHOD")    
+    if k8s_method == "LIST":
+        listConfigmaps(label, targetFolder, url, method, payload, namespace, folderAnnotation)
+    else:
+        while True:
+            try:
+                watchForChanges(label, targetFolder, url, method, payload, namespace, folderAnnotation)
+            except ApiException as e:
+                if "500" not in e:
+                  print("ApiException when calling kubernetes: %s\n" % e)
+                else:
+                  raise
+            except ProtocolError as e:
+                print("ProtocolError when calling kubernetes: %s\n" % e)
+            except:
+                raise
 
 
 if __name__ == '__main__':

--- a/sidecar/sidecar.py
+++ b/sidecar/sidecar.py
@@ -95,10 +95,10 @@ def watchForChanges(label, targetFolder, url, method, payload, current, folderAn
 def main():
     print("Starting config map collector")
     label = os.getenv('LABEL')
-    # I want this to be configurable, but I also don't want to hack up
-    # the upstream grafana chart right now. Hard coding this for now...
-    # folderAnnotation = os.getenv('FOLDER_ANNOTATIONS')
-    folderAnnotation = "k8s-sidecar-target-directory"
+    folderAnnotation = os.getenv('FOLDER_ANNOTATIONS')
+    if folderAnnotation is None:
+        print("No folder annotation was provided, defaulting to k8s-sidecar-target-directory")
+        folderAnnotation = "k8s-sidecar-target-directory"
     if label is None:
         print("Should have added LABEL as environment variable! Exit")
         return -1
@@ -121,7 +121,10 @@ def main():
         try:
             watchForChanges(label, targetFolder, url, method, payload, namespace, folderAnnotation)
         except ApiException as e:
-            print("ApiException when calling kubernetes: %s\n" % e)
+            if "500" not in e:
+              print("ApiException when calling kubernetes: %s\n" % e)
+            else:
+              raise
         except ProtocolError as e:
             print("ProtocolError when calling kubernetes: %s\n" % e)
         except:

--- a/sidecar/sidecar.py
+++ b/sidecar/sidecar.py
@@ -74,8 +74,6 @@ def watchForChanges(label, targetFolder, url, method, payload, current, folderAn
                     if folderAnnotation in event['object'].metadata.annotations.keys():
                         destFolder = event['object'].metadata.annotations[folderAnnotation]
                         print(f'Found a folder override annotation, placing the configmap in: {destFolder}')
-                    else:
-                        destFolder = targetFolder
 
             dataMap=event['object'].data
             if dataMap is None:


### PR DESCRIPTION
This PR adds functionality to allow a user to override the default target directory per configmap based on an annotation. I also ported the exception handling implemented in https://github.com/banzaicloud/k8s-sidecar/pull/1/files to prevent excessive container restarts