### PR TITLE
Add support for url download

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ By adding additional env variables the container can send a html request to spec
 
 Example for a simple deployment can be found in `example.yaml`. Depending on the cluster setup you have to grant yourself admin rights first: `kubectl create clusterrolebinding cluster-admin-binding   --clusterrole cluster-admin   --user $(gcloud config get-value account)`
 
+If the filename ends with `.url` prefix, the content will be processed as an URL the target file will be downloaded and used as the content file.
+
 ## Configuration Environment Variables
 
 - `LABEL` 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ By adding additional env variables the container can send a html request to spec
 
 Example for a simple deployment can be found in `example.yaml`. Depending on the cluster setup you have to grant yourself admin rights first: `kubectl create clusterrolebinding cluster-admin-binding   --clusterrole cluster-admin   --user $(gcloud config get-value account)`
 
-If the filename ends with `.url` prefix, the content will be processed as an URL the target file will be downloaded and used as the content file.
+If the filename ends with `.url` suffix, the content will be processed as an URL the target file will be downloaded and used as the content file.
 
 ## Configuration Environment Variables
 

--- a/sidecar/sidecar.py
+++ b/sidecar/sidecar.py
@@ -61,6 +61,10 @@ def listConfigmaps(label, targetFolder, url, method, payload, current):
                 continue
             if label in cm.metadata.labels.keys():
                 for filename in dataMap.keys():
+                    fileData = dataMap[filename]
+                    if filename.endswith(".url"):
+                        filename = filename[:-4]
+                        fileData = request(fileData, "GET").text
                     writeTextToFile(targetFolder, filename, dataMap[filename])
                     if url is not None:
                         request(url, method, payload)

--- a/sidecar/sidecar.py
+++ b/sidecar/sidecar.py
@@ -65,7 +65,7 @@ def listConfigmaps(label, targetFolder, url, method, payload, current):
                     if filename.endswith(".url"):
                         filename = filename[:-4]
                         fileData = request(fileData, "GET").text
-                    writeTextToFile(targetFolder, filename, dataMap[filename])
+                    writeTextToFile(targetFolder, filename, fileData)
                     if url is not None:
                         request(url, method, payload)
 

--- a/sidecar/sidecar.py
+++ b/sidecar/sidecar.py
@@ -12,7 +12,7 @@ def writeTextToFile(folder, filename, data):
         f.close()
 
 
-def request(url, method, payload):
+def request(url, method, payload = None):
     r = requests.Session()
     retries = Retry(total = 5,
             connect = 5,
@@ -29,7 +29,7 @@ def request(url, method, payload):
     elif method == "POST":
         res = r.post("%s" % url, json=payload, timeout=10)
         print ("%s request sent to %s. Response: %d %s" % (method, url, res.status_code, res.reason))
-
+    return res
 
 def removeFile(folder, filename):
     completeFile = folder +"/"+filename
@@ -92,10 +92,16 @@ def watchForChanges(label, targetFolder, url, method, payload, current):
             for filename in dataMap.keys():
                 print("File in configmap %s %s" % (filename, eventType))
                 if (eventType == "ADDED") or (eventType == "MODIFIED"):
-                    writeTextToFile(targetFolder, filename, dataMap[filename])
+                    fileData = dataMap[filename]
+                    if filename.endswith(".url"):
+                        filename = filename[:-4]
+                        fileData = request(fileData, "GET").text
+                    writeTextToFile(targetFolder, filename, fileData)
                     if url is not None:
                         request(url, method, payload)
                 else:
+                    if filename.endswith(".url"):
+                        filename = filename[:-4]
                     removeFile(targetFolder, filename)
                     if url is not None:
                         request(url, method, payload)


### PR DESCRIPTION
This PR help to solve the problem described in this issue: https://github.com/coreos/prometheus-operator/issues/2033

Usecases:
- A Grafana dashboard overcommiting the 1M configmap limit (revert annotation being part of it?).
- Hotlink from an official Grafana Dashboard, eg: https://grafana.com/api/dashboards/7173/revisions/2/download

A test image can be found here: [zadki3l/k8s-sidecar:download-url-support](https://hub.docker.com/r/zadki3l/k8s-sidecar)