### PR TITLE
Base64 Data Decoding Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Example for a simple deployment can be found in `example.yaml`. Depending on the
 
 If the filename ends with `.url` suffix, the content will be processed as an URL the target file will be downloaded and used as the content file.
 
+If the filename ends with `.base64` suffix, the content will be base64 decoded and persisted to disk.
+
 ## Configuration Environment Variables
 
 - `LABEL` 
@@ -69,9 +71,3 @@ If the filename ends with `.url` suffix, the content will be processed as an URL
   - description: Set to true to skip tls verification for kube api calls
   - required: false
   - type: boolean
-
-## Annotations
-
-| Annotation | Description |
-|------------|-------------|
-| `k8s-sidecar.kiwigrid/base64-data` | Tells the sidecar to treat the values in your `ConfigMap` as base64 encoded and saves the decoded output into the destination file |

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ By adding additional env variables the container can send a html request to spec
 - Extract files from config maps
 - Filter based on label
 - Update/Delete on change of configmap
+- Decode base64 data from within a configmap
 
 # Usage
 
@@ -68,3 +69,9 @@ If the filename ends with `.url` suffix, the content will be processed as an URL
   - description: Set to true to skip tls verification for kube api calls
   - required: false
   - type: boolean
+
+## Annotations
+
+| Annotation | Description |
+|------------|-------------|
+| `k8s-sidecar.kiwigrid/base64-data` | Tells the sidecar to treat the values in your `ConfigMap` as base64 encoded and saves the decoded output into the destination file |

--- a/sidecar/sidecar.py
+++ b/sidecar/sidecar.py
@@ -70,14 +70,6 @@ def listConfigmaps(label, targetFolder, url, method, payload, current):
                     if url is not None:
                         request(url, method, payload)
 
-def getAnnotation(obj, annotation):
-    if not hasattr(obj, 'metadata'):
-        return None
-    if not hasattr(obj.metadata, 'annotations'):
-        return None
-    return obj.metadata.annotations.get(annotation)
-
-
 def watchForChanges(label, targetFolder, url, method, payload, current):
     v1 = client.CoreV1Api()
     w = watch.Watch()
@@ -101,14 +93,12 @@ def watchForChanges(label, targetFolder, url, method, payload, current):
                 print("Configmap does not have data.")
                 continue
             eventType = event['type']
-            contentBase64Encoded = getAnnotation(event['object'], 'k8s-sidecar.kiwigrid/base64-data')
             for filename in dataMap.keys():
-                print("File in configmap %s %s" % (filename, eventType))
                 if (eventType == "ADDED") or (eventType == "MODIFIED"):
                     fileData = dataMap[filename]
-                    if contentBase64Encoded:
+                    if filename.endswith(".base64"):
                         fileData = base64.b64decode(fileData).decode()
-                    if filename.endswith(".url"):
+                    elif filename.endswith(".url"):
                         filename = filename[:-4]
                         fileData = request(fileData, "GET").text
                     writeTextToFile(targetFolder, filename, fileData)


### PR DESCRIPTION
Added support for `.base64` filename suffix to allow decoding base64 data.

For us this gets around some terrible escaping issues we're seeing with our CICD platform (Spinnaker). Instead of escaping all of our `$variable`s in a dashboard to be `${"$variable"}` (which makes it unreadable and impossible to lint), so now we just base64 our JSON and save that in the `ConfigMap`