### PR TITLE
Configurable request error settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,12 @@ If the filename ends with `.url` suffix, the content will be processed as an URL
   - default: 0.2
   - type: float
 
+- `REQ_TIMEOUT`
+  - description: many seconds to wait for the server to send data before giving up
+  - required: false
+  - default: 10
+  - type: float
+
 - `SKIP_TLS_VERIFY`
   - description: Set to true to skip tls verification for kube api calls
   - required: false

--- a/README.md
+++ b/README.md
@@ -84,6 +84,12 @@ If the filename ends with `.url` suffix, the content will be processed as an URL
   - default: 5
   - type: integer
 
+- `REQ_RETRY_READ`
+  - description: How many times to retry on read errors
+  - required: false
+  - default: 5
+  - type: integer
+
 - `REQ_RETRY_BACKOFF_FACTOR`
   - description: A backoff factor to apply between attempts after the second try
   - required: false

--- a/README.md
+++ b/README.md
@@ -72,6 +72,24 @@ If the filename ends with `.url` suffix, the content will be processed as an URL
   - required: false
   - type: json
 
+- `REQ_RETRY_TOTAL`
+  - description: Total number of retries to allow
+  - required: false
+  - default: 5
+  - type: integer
+
+- `REQ_RETRY_CONNECT`
+  - description: How many connection-related errors to retry on
+  - required: false
+  - default: 5
+  - type: integer
+
+- `REQ_RETRY_BACKOFF_FACTOR`
+  - description: A backoff factor to apply between attempts after the second try
+  - required: false
+  - default: 0.2
+  - type: float
+
 - `SKIP_TLS_VERIFY`
   - description: Set to true to skip tls verification for kube api calls
   - required: false

--- a/sidecar/sidecar.py
+++ b/sidecar/sidecar.py
@@ -26,6 +26,7 @@ def request(url, method, payload = None):
     retryConnect = 5 if os.getenv('REQ_RETRY_CONNECT') is None else int(os.getenv('REQ_RETRY_CONNECT'))
     retryRead = 5 if os.getenv('REQ_RETRY_READ') is None else int(os.getenv('REQ_RETRY_READ'))
     retryBackoffFactor = 0.2 if os.getenv('REQ_RETRY_BACKOFF_FACTOR') is None else float(os.getenv('REQ_RETRY_BACKOFF_FACTOR'))
+    timeout = 10 if os.getenv('REQ_TIMEOUT') is None else float(os.getenv('REQ_TIMEOUT'))
 
     r = requests.Session()
     retries = Retry(total = retryTotal,
@@ -39,10 +40,10 @@ def request(url, method, payload = None):
         print("No url provided. Doing nothing.")
         # If method is not provided use GET as default
     elif method == "GET" or method is None:
-        res = r.get("%s" % url, timeout=10)
+        res = r.get("%s" % url, timeout=timeout)
         print ("%s request sent to %s. Response: %d %s" % (method, url, res.status_code, res.reason))
     elif method == "POST":
-        res = r.post("%s" % url, json=payload, timeout=10)
+        res = r.post("%s" % url, json=payload, timeout=timeout)
         print ("%s request sent to %s. Response: %d %s" % (method, url, res.status_code, res.reason))
     return res
 

--- a/sidecar/sidecar.py
+++ b/sidecar/sidecar.py
@@ -22,10 +22,14 @@ def writeTextToFile(folder, filename, data):
 
 
 def request(url, method, payload = None):
+    retryTotal = 5 if os.getenv('REQ_RETRY_TOTAL') is None else int(os.getenv('REQ_RETRY_TOTAL'))
+    retryConnect = 5 if os.getenv('REQ_RETRY_CONNECT') is None else int(os.getenv('REQ_RETRY_CONNECT'))
+    retryBackoffFactor = 0.2 if os.getenv('REQ_RETRY_BACKOFF_FACTOR') is None else float(os.getenv('REQ_RETRY_BACKOFF_FACTOR'))
+
     r = requests.Session()
-    retries = Retry(total = 5,
-            connect = 5,
-            backoff_factor = 0.2,
+    retries = Retry(total = retryTotal,
+            connect = retryConnect,
+            backoff_factor = retryBackoffFactor,
             status_forcelist = [ 500, 502, 503, 504 ])
     r.mount('http://', HTTPAdapter(max_retries=retries))
     r.mount('https://', HTTPAdapter(max_retries=retries))

--- a/sidecar/sidecar.py
+++ b/sidecar/sidecar.py
@@ -24,11 +24,13 @@ def writeTextToFile(folder, filename, data):
 def request(url, method, payload = None):
     retryTotal = 5 if os.getenv('REQ_RETRY_TOTAL') is None else int(os.getenv('REQ_RETRY_TOTAL'))
     retryConnect = 5 if os.getenv('REQ_RETRY_CONNECT') is None else int(os.getenv('REQ_RETRY_CONNECT'))
+    retryRead = 5 if os.getenv('REQ_RETRY_READ') is None else int(os.getenv('REQ_RETRY_READ'))
     retryBackoffFactor = 0.2 if os.getenv('REQ_RETRY_BACKOFF_FACTOR') is None else float(os.getenv('REQ_RETRY_BACKOFF_FACTOR'))
 
     r = requests.Session()
     retries = Retry(total = retryTotal,
             connect = retryConnect,
+            read = retryRead,
             backoff_factor = retryBackoffFactor,
             status_forcelist = [ 500, 502, 503, 504 ])
     r.mount('http://', HTTPAdapter(max_retries=retries))


### PR DESCRIPTION
* Expose retry settings as configurable environment variables with previously hardcoded values as defaults.
* Same for timeout settings.
* Retry (w/ the same configurability) on read errors.

Basically fixes stuff mentioned in #23.