### PR TITLE
Allow secrets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,6 @@ FROM        python:3.7-slim
 WORKDIR     /app
 COPY        requirements.txt .
 RUN         pip install -r requirements.txt
-COPY        sidecar/sidecar.py .
+COPY        sidecar/* ./
 ENV         PYTHONUNBUFFERED=1
 CMD         [ "python", "-u", "/app/sidecar.py" ]

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ If the filename ends with `.url` suffix, the content will be processed as an URL
 
 ## Configuration Environment Variables
 
-- `LABEL` 
+- `LABEL`
   - description: Label that should be used for filtering
   - required: true
   - type: string
@@ -52,11 +52,17 @@ If the filename ends with `.url` suffix, the content will be processed as an URL
   - required: false
   - type: string
 
+- `RESOURCE`
+  - description: Resouce type, which is monitored by the sidecar. Options: configmap (default), secret, both
+  - required: false
+  - default: configmap
+  - type: string
+
 - `METHOD`
   - description: If `METHOD` is set with `LIST`, the sidecar will just list config-maps and exit. Default is watch.
   - required: false
   - type: string
-  
+
 - `REQ_URL`
   - description: URL to which send a request after a configmap got reloaded
   - required: false

--- a/example.yaml
+++ b/example.yaml
@@ -33,6 +33,8 @@ spec:
           value: "findme"
         - name: FOLDER
           value: /tmp/
+        - name: RESOURCE
+          value: both
       volumes:
       - name: shared-volume
         emptyDir: {}
@@ -47,13 +49,24 @@ data:
   hello.world: |-
      Hello World!
 ---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: sample-secret
+  labels:
+    findme: "yea"
+type: Opaque
+data:
+  # base64 encoded: my super cool \n multiline \ secret
+  secret.world: bXkgc3VwZXIgY29vbAptdWx0aWxpbmUKc2VjcmV0
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: sample-role
 rules:
 - apiGroups: [""]
-  resources: ["configmaps"]
+  resources: ["configmaps", "secrets"]
   verbs: ["get", "watch", "list"]
 ---
 apiVersion: v1

--- a/sidecar/helpers.py
+++ b/sidecar/helpers.py
@@ -1,0 +1,57 @@
+import os
+import errno
+
+import requests
+from requests.packages.urllib3.util.retry import Retry
+from requests.adapters import HTTPAdapter
+
+
+def writeTextToFile(folder, filename, data):
+    if not os.path.exists(folder):
+        try:
+            os.makedirs(folder)
+        except OSError as e:
+            if e.errno != errno.EEXIST:
+                raise
+
+    with open(folder + "/" + filename, 'w') as f:
+        f.write(data)
+        f.close()
+
+
+def removeFile(folder, filename):
+    completeFile = folder + "/" + filename
+    if os.path.isfile(completeFile):
+        os.remove(completeFile)
+    else:
+        print(f"Error: {completeFile} file not found")
+
+
+def request(url, method, payload=None):
+    retryTotal = 5 if os.getenv('REQ_RETRY_TOTAL') is None else int(os.getenv('REQ_RETRY_TOTAL'))
+    retryConnect = 5 if os.getenv('REQ_RETRY_CONNECT') is None else int(
+        os.getenv('REQ_RETRY_CONNECT'))
+    retryRead = 5 if os.getenv('REQ_RETRY_READ') is None else int(os.getenv('REQ_RETRY_READ'))
+    retryBackoffFactor = 0.2 if os.getenv('REQ_RETRY_BACKOFF_FACTOR') is None else float(
+        os.getenv('REQ_RETRY_BACKOFF_FACTOR'))
+    timeout = 10 if os.getenv('REQ_TIMEOUT') is None else float(os.getenv('REQ_TIMEOUT'))
+
+    r = requests.Session()
+    retries = Retry(total=retryTotal,
+                    connect=retryConnect,
+                    read=retryRead,
+                    backoff_factor=retryBackoffFactor,
+                    status_forcelist=[500, 502, 503, 504])
+    r.mount('http://', HTTPAdapter(max_retries=retries))
+    r.mount('https://', HTTPAdapter(max_retries=retries))
+    if url is None:
+        print("No url provided. Doing nothing.")
+        return
+
+    # If method is not provided use GET as default
+    if method == "GET" or not method:
+        res = r.get("%s" % url, timeout=timeout)
+    elif method == "POST":
+        res = r.post("%s" % url, json=payload, timeout=timeout)
+        print(f"{method} request sent to {url}. Response: {res.status_code} {res.reason}")
+    return res

--- a/sidecar/resources.py
+++ b/sidecar/resources.py
@@ -1,0 +1,141 @@
+import base64
+import os
+from threading import Thread
+
+from kubernetes import client, watch
+from kubernetes.client.rest import ApiException
+from urllib3.exceptions import ProtocolError
+
+from helpers import request, writeTextToFile, removeFile
+
+_list_namespaced = {
+    "secret": "list_namespaced_secret",
+    "configmap": "list_namespaced_config_map"
+}
+
+_list_for_all_namespaces = {
+    "secret": "list_secret_for_all_namespaces",
+    "configmap": "list_config_map_for_all_namespaces"
+}
+
+
+def _get_file_data_and_name(full_filename, content, resource):
+    if resource == "secret":
+        file_data = base64.b64decode(content).decode()
+    else:
+        file_data = content
+
+    if full_filename.endswith(".url"):
+        filename = full_filename[:-4]
+        file_data = request(file_data, "GET").text
+    else:
+        filename = full_filename
+
+    return filename, file_data
+
+
+def listResources(label, targetFolder, url, method, payload, current, folderAnnotation, resource):
+    v1 = client.CoreV1Api()
+    namespace = os.getenv("NAMESPACE", current)
+    if namespace == "ALL":
+        ret = getattr(v1, _list_for_all_namespaces[resource])()
+    else:
+        ret = getattr(v1, _list_namespaced[resource])(namespace=namespace)
+
+    for sec in ret.items:
+        destFolder = targetFolder
+        metadata = sec.metadata
+        if metadata.labels is None:
+            continue
+        print(f'Working on {resource}: {metadata.namespace}/{metadata.name}')
+        if label in sec.metadata.labels.keys():
+            print(f"Found {resource} with label")
+            if sec.metadata.annotations is not None:
+                if folderAnnotation in sec.metadata.annotations.keys():
+                    destFolder = sec.metadata.annotations[folderAnnotation]
+
+            dataMap = sec.data
+            if dataMap is None:
+                print(f"No data field in {resource}")
+                continue
+
+            if label in sec.metadata.labels.keys():
+                for data_key in dataMap.keys():
+                    filename, filedata = _get_file_data_and_name(data_key, dataMap[data_key],
+                                                                 resource)
+                    writeTextToFile(destFolder, filename, filedata)
+
+                    if url is not None:
+                        request(url, method, payload)
+
+
+def _watch_resource_iterator(label, targetFolder, url, method, payload,
+                             current, folderAnnotation, resource, thread):
+    print_prefix = "Thread: " if thread else ""
+    v1 = client.CoreV1Api()
+    namespace = os.getenv("NAMESPACE", current)
+    if namespace == "ALL":
+        stream = watch.Watch().stream(getattr(v1, _list_for_all_namespaces[resource]))
+    else:
+        stream = watch.Watch().stream(getattr(v1, _list_namespaced[resource]), namespace=namespace)
+
+    for event in stream:
+        destFolder = targetFolder
+        metadata = event['object'].metadata
+        if metadata.labels is None:
+            continue
+        print(f'{print_prefix}Working on {resource} {metadata.namespace}/{metadata.name}')
+        if label in event['object'].metadata.labels.keys():
+            print(f"{print_prefix}{resource} with label found")
+            if event['object'].metadata.annotations is not None:
+                if folderAnnotation in event['object'].metadata.annotations.keys():
+                    destFolder = event['object'].metadata.annotations[folderAnnotation]
+                    print(f'{print_prefix}ound a folder override annotation, '
+                          'placing the {resource} in: {destFolder}')
+            dataMap = event['object'].data
+            if dataMap is None:
+                print(f"{print_prefix}{resource} does not have data.")
+                continue
+            eventType = event['type']
+            for data_key in dataMap.keys():
+                print(f"{print_prefix}File in {resource} {data_key} {eventType}")
+
+                if (eventType == "ADDED") or (eventType == "MODIFIED"):
+                    filename, filedata = _get_file_data_and_name(data_key, dataMap[data_key],
+                                                                 resource)
+                    writeTextToFile(destFolder, filename, filedata)
+
+                    if url is not None:
+                        request(url, method, payload)
+                else:
+                    filename = data_key[:-4] if data_key.endswith(".url") else data_key
+                    removeFile(destFolder, filename)
+                    if url is not None:
+                        request(url, method, payload)
+
+
+def _watch_resource_loop(*args):
+    try:
+        _watch_resource_iterator(*args)
+    except ApiException as e:
+        if e.status != 500:
+            print(f"ApiException when calling kubernetes: {e}\n")
+        else:
+            raise
+    except ProtocolError as e:
+        print(f"ProtocolError when calling kubernetes: {e}\n")
+    except Exception as e:
+        print(f"Received unknown exception: {e}\n")
+
+
+def watchForChanges(label, targetFolder, url, method, payload,
+                    current, folderAnnotation, resources):
+
+    if len(resources) == 2:
+        Thread(target=_watch_resource_loop,
+               args=(label, targetFolder, url, method, payload,
+                     current, folderAnnotation, resources[1], True)
+               ).start()
+
+    _watch_resource_loop(label, targetFolder, url, method, payload,
+                         current, folderAnnotation, resources[0], False)

--- a/sidecar/sidecar.py
+++ b/sidecar/sidecar.py
@@ -1,160 +1,31 @@
-from kubernetes import client, config, watch
 import os
-import errno
-import requests
-from kubernetes.client.rest import ApiException
-from urllib3.exceptions import ProtocolError
-from requests.packages.urllib3.util.retry import Retry
-from requests.adapters import HTTPAdapter
 
+from kubernetes import client, config
 
-def writeTextToFile(folder, filename, data):
-    if not os.path.exists(folder):
-        try:
-            os.makedirs(folder)
-        except OSError as e:
-            if e.errno != errno.EEXIST:
-                raise
-
-    with open(folder + "/" + filename, 'w') as f:
-        f.write(data)
-        f.close()
-
-
-def request(url, method, payload=None):
-    retryTotal = 5 if os.getenv('REQ_RETRY_TOTAL') is None else int(os.getenv('REQ_RETRY_TOTAL'))
-    retryConnect = 5 if os.getenv('REQ_RETRY_CONNECT') is None else int(
-        os.getenv('REQ_RETRY_CONNECT'))
-    retryRead = 5 if os.getenv('REQ_RETRY_READ') is None else int(os.getenv('REQ_RETRY_READ'))
-    retryBackoffFactor = 0.2 if os.getenv('REQ_RETRY_BACKOFF_FACTOR') is None else float(
-        os.getenv('REQ_RETRY_BACKOFF_FACTOR'))
-    timeout = 10 if os.getenv('REQ_TIMEOUT') is None else float(os.getenv('REQ_TIMEOUT'))
-
-    r = requests.Session()
-    retries = Retry(total=retryTotal,
-                    connect=retryConnect,
-                    read=retryRead,
-                    backoff_factor=retryBackoffFactor,
-                    status_forcelist=[500, 502, 503, 504])
-    r.mount('http://', HTTPAdapter(max_retries=retries))
-    r.mount('https://', HTTPAdapter(max_retries=retries))
-    if url is None:
-        print("No url provided. Doing nothing.")
-        # If method is not provided use GET as default
-    elif method == "GET" or method is None:
-        res = r.get("%s" % url, timeout=timeout)
-        print("%s request sent to %s. Response: %d %s" % (method, url, res.status_code, res.reason))
-    elif method == "POST":
-        res = r.post("%s" % url, json=payload, timeout=timeout)
-        print("%s request sent to %s. Response: %d %s" % (method, url, res.status_code, res.reason))
-    return res
-
-
-def removeFile(folder, filename):
-    completeFile = folder + "/"+filename
-    if os.path.isfile(completeFile):
-        os.remove(completeFile)
-    else:
-        print("Error: %s file not found" % completeFile)
-
-
-def listConfigmaps(label, targetFolder, url, method, payload, current, folderAnnotation):
-    v1 = client.CoreV1Api()
-    namespace = os.getenv("NAMESPACE")
-    if namespace is None:
-        ret = v1.list_namespaced_config_map(namespace=current)
-    elif namespace == "ALL":
-        ret = v1.list_config_map_for_all_namespaces()
-    else:
-        ret = v1.list_namespaced_config_map(namespace=namespace)
-    for cm in ret.items:
-        destFolder = targetFolder
-        metadata = cm.metadata
-        if metadata.labels is None:
-            continue
-        print(f'Working on configmap {metadata.namespace}/{metadata.name}')
-        if label in cm.metadata.labels.keys():
-            print("Configmap with label found")
-            if cm.metadata.annotations is not None:
-                if folderAnnotation in cm.metadata.annotations.keys():
-                    destFolder = cm.metadata.annotations[folderAnnotation]
-
-            dataMap = cm.data
-            if dataMap is None:
-                print("Configmap does not have data.")
-                continue
-            if label in cm.metadata.labels.keys():
-                for filename in dataMap.keys():
-                    fileData = dataMap[filename]
-                    if filename.endswith(".url"):
-                        filename = filename[:-4]
-                        fileData = request(fileData, "GET").text
-                    writeTextToFile(destFolder, filename, fileData)
-                    if url is not None:
-                        request(url, method, payload)
-
-
-def watchForChanges(label, targetFolder, url, method, payload, current, folderAnnotation):
-    v1 = client.CoreV1Api()
-    w = watch.Watch()
-    stream = None
-    namespace = os.getenv("NAMESPACE")
-    if namespace is None:
-        stream = w.stream(v1.list_namespaced_config_map, namespace=current)
-    elif namespace == "ALL":
-        stream = w.stream(v1.list_config_map_for_all_namespaces)
-    else:
-        stream = w.stream(v1.list_namespaced_config_map, namespace=namespace)
-    for event in stream:
-        destFolder = targetFolder
-        metadata = event['object'].metadata
-        if metadata.labels is None:
-            continue
-        print(f'Working on configmap {metadata.namespace}/{metadata.name}')
-        if label in event['object'].metadata.labels.keys():
-            print("Configmap with label found")
-            if event['object'].metadata.annotations is not None:
-                if folderAnnotation in event['object'].metadata.annotations.keys():
-                    destFolder = event['object'].metadata.annotations[folderAnnotation]
-                    print('Found a folder override annotation, '
-                          'placing the configmap in: {destFolder}')
-            dataMap = event['object'].data
-            if dataMap is None:
-                print("Configmap does not have data.")
-                continue
-            eventType = event['type']
-            for filename in dataMap.keys():
-                print("File in configmap %s %s" % (filename, eventType))
-                if (eventType == "ADDED") or (eventType == "MODIFIED"):
-                    fileData = dataMap[filename]
-                    if filename.endswith(".url"):
-                        filename = filename[:-4]
-                        fileData = request(fileData, "GET").text
-                    writeTextToFile(destFolder, filename, fileData)
-                    if url is not None:
-                        request(url, method, payload)
-                else:
-                    if filename.endswith(".url"):
-                        filename = filename[:-4]
-                    removeFile(destFolder, filename)
-                    if url is not None:
-                        request(url, method, payload)
+from resources import listResources, watchForChanges
 
 
 def main():
-    print("Starting config map collector")
+    print("Starting collector")
+
     folderAnnotation = os.getenv('FOLDER_ANNOTATIONS')
     if folderAnnotation is None:
         print("No folder annotation was provided, defaulting to k8s-sidecar-target-directory")
         folderAnnotation = "k8s-sidecar-target-directory"
+
     label = os.getenv('LABEL')
     if label is None:
         print("Should have added LABEL as environment variable! Exit")
         return -1
+
     targetFolder = os.getenv('FOLDER')
     if targetFolder is None:
         print("Should have added FOLDER as environment variable! Exit")
         return -1
+
+    resources = os.getenv('RESOURCE', 'configmap')
+    resources = ("secret", "configmap") if resources == "both" else (resources, )
+    print(f"Selected resource type: {resources}")
 
     method = os.getenv('REQ_METHOD')
     url = os.getenv('REQ_URL')
@@ -170,23 +41,13 @@ def main():
         configuration.debug = False
         client.Configuration.set_default(configuration)
 
-    k8s_method = os.getenv("METHOD")
-    if k8s_method == "LIST":
-        listConfigmaps(label, targetFolder, url, method, payload, namespace, folderAnnotation)
+    if os.getenv("METHOD") == "LIST":
+        for res in resources:
+            listResources(label, targetFolder, url, method, payload,
+                          namespace, folderAnnotation, res)
     else:
-        while True:
-            try:
-                watchForChanges(label, targetFolder, url, method,
-                                payload, namespace, folderAnnotation)
-            except ApiException as e:
-                if e.status != 500:
-                    print("ApiException when calling kubernetes: %s\n" % e)
-                else:
-                    raise
-            except ProtocolError as e:
-                print("ProtocolError when calling kubernetes: %s\n" % e)
-            except Exception:
-                raise
+        watchForChanges(label, targetFolder, url, method,
+                        payload, namespace, folderAnnotation, resources)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
PR relating to [issue 31](https://github.com/kiwigrid/k8s-sidecar/issues/31).

The first commit was simple refactoring according to flake8.

The second commit touched a lot of files as the single file approach would have been to messy in my opinion. I separated the logic into three files.

There was also a little problem with running two endless iterators in python, which I solved using Threads (only when we really want to watch secrets and configmaps both)