### PR TITLE
Add method that list resources and then sleeps for 60 seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ If the filename ends with `.url` suffix, the content will be processed as an URL
   - type: string
 
 - `METHOD`
-  - description: If `METHOD` is set with `LIST`, the sidecar will just list config-maps and exit. Default is watch.
+  - description: If `METHOD` is set with `LIST`, the sidecar will just list config-maps and exit. With `SLEEP` it will list all config-maps, then sleep for 60 seconds. Default is watch.
   - required: false
   - type: string
 

--- a/sidecar/resources.py
+++ b/sidecar/resources.py
@@ -114,10 +114,14 @@ def _watch_resource_iterator(label, targetFolder, url, method, payload,
                         request(url, method, payload)
 
 
-def _watch_resource_loop(*args):
+def _watch_resource_loop(mode, *args):
     while True:
         try:
-            _watch_resource_iterator(*args)
+            if mode == "SLEEP":
+                listResources(*args)
+                sleep(60)
+            else:
+                _watch_resource_iterator(*args)
         except ApiException as e:
             if e.status != 500:
                 print(f"ApiException when calling kubernetes: {e}\n")
@@ -129,18 +133,18 @@ def _watch_resource_loop(*args):
             print(f"Received unknown exception: {e}\n")
 
 
-def watchForChanges(label, targetFolder, url, method, payload,
+def watchForChanges(mode, label, targetFolder, url, method, payload,
                     current, folderAnnotation, resources):
 
     firstProc = Process(target=_watch_resource_loop,
-                        args=(label, targetFolder, url, method, payload,
+                        args=(mode, label, targetFolder, url, method, payload,
                               current, folderAnnotation, resources[0])
                         )
     firstProc.start()
 
     if len(resources) == 2:
         secProc = Process(target=_watch_resource_loop,
-                          args=(label, targetFolder, url, method, payload,
+                          args=(mode, label, targetFolder, url, method, payload,
                                 current, folderAnnotation, resources[1])
                           )
         secProc.start()

--- a/sidecar/sidecar.py
+++ b/sidecar/sidecar.py
@@ -46,7 +46,7 @@ def main():
             listResources(label, targetFolder, url, method, payload,
                           namespace, folderAnnotation, res)
     else:
-        watchForChanges(label, targetFolder, url, method,
+        watchForChanges(os.getenv("METHOD"), label, targetFolder, url, method,
                         payload, namespace, folderAnnotation, resources)
 
 


### PR DESCRIPTION
Add method that list resources and then sleeps for 60 seconds as an alternative to WATCH requests

This fixes issues where long running watch requests may break because of assumptions in software defined network solutions.