### PR TITLE
Add capability to filter based on label value

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ If the filename ends with `.url` suffix, the content will be processed as an URL
   - required: true
   - type: string
 
+- `LABEL_VALUE`
+  - description: The value for the label you want to filter your resources on. Don't set a value to filter by any value
+  - required: false
+  - type: string
+
 - `FOLDER`
   - description: Folder where the files should be placed
   - required: true

--- a/sidecar/resources.py
+++ b/sidecar/resources.py
@@ -59,7 +59,7 @@ def listResources(label, targetFolder, url, method, payload, current, folderAnno
         if metadata.labels is None:
             continue
         print(f'Working on {resource}: {metadata.namespace}/{metadata.name}')
-        if label in sec.metadata.labels.keys():
+        if label in metadata.labels.keys():
             print(f"Found {resource} with label")
 
             dataMap = sec.data
@@ -67,7 +67,7 @@ def listResources(label, targetFolder, url, method, payload, current, folderAnno
                 print(f"No data field in {resource}")
                 continue
 
-            if label in sec.metadata.labels.keys():
+            if label in metadata.labels.keys():
                 for data_key in dataMap.keys():
                     filename, filedata = _get_file_data_and_name(data_key, dataMap[data_key],
                                                                  resource)
@@ -93,7 +93,7 @@ def _watch_resource_iterator(label, targetFolder, url, method, payload,
         if metadata.labels is None:
             continue
         print(f'Working on {resource} {metadata.namespace}/{metadata.name}')
-        if label in event['object'].metadata.labels.keys():
+        if label in metadata.labels.keys():
             print(f"{resource} with label found")
             dataMap = event['object'].data
             if dataMap is None:

--- a/sidecar/resources.py
+++ b/sidecar/resources.py
@@ -73,7 +73,7 @@ def listResources(label, targetFolder, url, method, payload, current, folderAnno
                                                                  resource)
                     writeTextToFile(destFolder, filename, filedata)
 
-                    if url is not None:
+                    if url:
                         request(url, method, payload)
 
 
@@ -108,12 +108,12 @@ def _watch_resource_iterator(label, targetFolder, url, method, payload,
                                                                  resource)
                     writeTextToFile(destFolder, filename, filedata)
 
-                    if url is not None:
+                    if url:
                         request(url, method, payload)
                 else:
                     filename = data_key[:-4] if data_key.endswith(".url") else data_key
                     removeFile(destFolder, filename)
-                    if url is not None:
+                    if url:
                         request(url, method, payload)
 
 

--- a/sidecar/resources.py
+++ b/sidecar/resources.py
@@ -71,9 +71,9 @@ def listResources(label, targetFolder, url, method, payload, current, folderAnno
 
 
 def _watch_resource_iterator(label, targetFolder, url, method, payload,
-                             current, folderAnnotation, resource):
+                             current_namespace, folderAnnotation, resource):
     v1 = client.CoreV1Api()
-    namespace = os.getenv("NAMESPACE", current)
+    namespace = os.getenv("NAMESPACE", current_namespace)
     if namespace == "ALL":
         stream = watch.Watch().stream(getattr(v1, _list_for_all_namespaces[resource]))
     else:
@@ -130,18 +130,18 @@ def _watch_resource_loop(*args):
 
 
 def watchForChanges(label, targetFolder, url, method, payload,
-                    current, folderAnnotation, resources):
+                    current_namespace, folderAnnotation, resources):
 
     firstProc = Process(target=_watch_resource_loop,
                         args=(label, targetFolder, url, method, payload,
-                              current, folderAnnotation, resources[0])
+                              current_namespace, folderAnnotation, resources[0])
                         )
     firstProc.start()
 
     if len(resources) == 2:
         secProc = Process(target=_watch_resource_loop,
                           args=(label, targetFolder, url, method, payload,
-                                current, folderAnnotation, resources[1])
+                                current_namespace, folderAnnotation, resources[1])
                           )
         secProc.start()
 

--- a/sidecar/sidecar.py
+++ b/sidecar/sidecar.py
@@ -18,6 +18,10 @@ def main():
         print("Should have added LABEL as environment variable! Exit")
         return -1
 
+    labelValue = os.getenv('LABEL_VALUE')
+    if labelValue:
+        print(f"Filter labels with value: {labelValue}")
+
     targetFolder = os.getenv('FOLDER')
     if targetFolder is None:
         print("Should have added FOLDER as environment variable! Exit")
@@ -33,7 +37,7 @@ def main():
 
     config.load_incluster_config()
     print("Config for cluster api loaded...")
-    current_namespace = open("/var/run/secrets/kubernetes.io/serviceaccount/namespace").read()
+    currentNamespace = open("/var/run/secrets/kubernetes.io/serviceaccount/namespace").read()
 
     if os.getenv('SKIP_TLS_VERIFY') == 'true':
         configuration = client.Configuration()
@@ -43,11 +47,11 @@ def main():
 
     if os.getenv("METHOD") == "LIST":
         for res in resources:
-            listResources(label, targetFolder, url, method, payload,
-                          current_namespace, folderAnnotation, res)
+            listResources(label, labelValue, targetFolder, url, method, payload,
+                          currentNamespace, folderAnnotation, res)
     else:
-        watchForChanges(label, targetFolder, url, method,
-                        payload, current_namespace, folderAnnotation, resources)
+        watchForChanges(label, labelValue, targetFolder, url, method,
+                        payload, currentNamespace, folderAnnotation, resources)
 
 
 if __name__ == '__main__':

--- a/sidecar/sidecar.py
+++ b/sidecar/sidecar.py
@@ -33,7 +33,7 @@ def main():
 
     config.load_incluster_config()
     print("Config for cluster api loaded...")
-    namespace = open("/var/run/secrets/kubernetes.io/serviceaccount/namespace").read()
+    current_namespace = open("/var/run/secrets/kubernetes.io/serviceaccount/namespace").read()
 
     if os.getenv('SKIP_TLS_VERIFY') == 'true':
         configuration = client.Configuration()
@@ -44,10 +44,10 @@ def main():
     if os.getenv("METHOD") == "LIST":
         for res in resources:
             listResources(label, targetFolder, url, method, payload,
-                          namespace, folderAnnotation, res)
+                          current_namespace, folderAnnotation, res)
     else:
         watchForChanges(label, targetFolder, url, method,
-                        payload, namespace, folderAnnotation, resources)
+                        payload, current_namespace, folderAnnotation, resources)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Instead of having multiple labels configured with on multiple deployments we prefer to use the same label but with different values. Eg:

```
# Get pods with label... and any value
kubectl get configmap --selector grafana-dashboard

# Filter by label and value
kubectl get configmap --selector grafana-dashboard=team-name
```
This feature is also available on K8s Python client
https://github.com/kubernetes-client/python/blob/master/kubernetes/docs/CoreV1Api.md#list_namespaced_secret

As you can see the main motivation for this is to be able to use multiple sidecars on Grafana and put each team dashboard on their own folder.
We need to add more sidecars and dashboard provisioners with different folders
https://grafana.com/docs/administration/provisioning/#dashboards

I hope this makes sense.