### PR TITLE
fix folder annotation env variable name

### DIFF
--- a/sidecar/sidecar.py
+++ b/sidecar/sidecar.py
@@ -8,7 +8,7 @@ from resources import listResources, watchForChanges
 def main():
     print("Starting collector")
 
-    folderAnnotation = os.getenv('FOLDER_ANNOTATIONS')
+    folderAnnotation = os.getenv('FOLDER_ANNOTATION')
     if folderAnnotation is None:
         print("No folder annotation was provided, defaulting to k8s-sidecar-target-directory")
         folderAnnotation = "k8s-sidecar-target-directory"


### PR DESCRIPTION
The name of the env variable that controls the folder annotation is `FOLDER_ANNOTATION` in the docs, but `FOLDER_ANNOTATIONS` in code.

This PR changes it to be `FOLDER_ANNOTATION` as it should according to the docs. Could change the docs instead, but the name `FOLDER_ANNOTATIONS` is confusing because there is only one annotation.