### PR TITLE
don't retry file when a folder can't be created due to permissions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.iml
 .idea/
+venv

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 # What?
 
-This is a docker container intended to run inside a kubernetes cluster to collect config maps with a specified label and store the included files in an local folder. It can also send an HTTP request to a specified URL after a configmap change. The main target is to be run as a sidecar container to supply an application with information from the cluster. The contained Python script is working with the Kubernetes API 1.10
+This is a docker container intended to run inside a kubernetes cluster to collect config maps with a specified label and store the included files in an local folder. It can also send an HTTP request to a specified URL after a configmap change. The main target is to be run as a sidecar container to supply an application with information from the cluster. The contained Python script is working with the Kubernetes API 1.16.
 
 # Why?
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 # What?
 
-This is a docker container intended to run inside a kubernetes cluster to collect config maps with a specified label and store the included files in an local folder. It can also send an HTTP request to a specified URL after a configmap change. The main target is to be run as a sidecar container to supply an application with information from the cluster. The contained Python script is working with the Kubernetes API 1.16.
+This is a docker container intended to run inside a kubernetes cluster to collect config maps with a specified label and store the included files in an local folder. It can also send an HTTP request to a specified URL after a configmap change. The main target is to be run as a sidecar container to supply an application with information from the cluster. The contained Python script is working from Kubernetes API 1.10.
 
 # Why?
 

--- a/sidecar/helpers.py
+++ b/sidecar/helpers.py
@@ -9,20 +9,27 @@ from requests.adapters import HTTPAdapter
 
 
 def writeTextToFile(folder, filename, data):
+    """
+    Write text to a file. If the parent folder doesn't exist, create it. If there are insufficient
+    permissions to create the directory, log an error and return.
+    """
     if not os.path.exists(folder):
         try:
             os.makedirs(folder)
         except OSError as e:
-            if e.errno != errno.EEXIST:
+            if e.errno not in (errno.EACCES, errno.EEXIST):
                 raise
+            if e.errno == errno.EACCES:
+                print(f"Error: insufficient privileges to create {folder}. Skipping {filename}.")
+                return
 
-    with open(folder + "/" + filename, 'w') as f:
+    with open(os.path.join(folder, filename), 'w') as f:
         f.write(data)
         f.close()
 
 
 def removeFile(folder, filename):
-    completeFile = folder + "/" + filename
+    completeFile = os.path.join(folder, filename)
     if os.path.isfile(completeFile):
         os.remove(completeFile)
     else:


### PR DESCRIPTION
1. added venv to gitignore because that's how intellij happened to set things up
1. bumped compatible k8s version in README, because things seem to work fine in 1.16
1. used os.path.join (which may be silly, this code is only going to run on linux - habits die hard)
1. handled folder-creation permissions error

Pro: no endless loop or exploding logs due to a folder that can (probably) never be created
Con: if there's some use case where write permissions are granted on the parent folder _during runtime_, k8s-sidecar won't create it until the next configmap change.

This may or may not be an awesome idea. I just found it helpful in my work.