### PR TITLE
Update to enable generating unique filenames 

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ By adding additional env variables the container can send an HTTP request to spe
 - Extract files from config maps
 - Filter based on label
 - Update/Delete on change of configmap
+- Enforce unique filenames
 
 # Usage
 
@@ -117,6 +118,12 @@ If the filename ends with `.url` suffix, the content will be processed as an URL
 - `SKIP_TLS_VERIFY`
   - description: Set to true to skip tls verification for kube api calls
   - required: false
+  - type: boolean
+
+- `UNIQUE_FILENAMES`
+  - description: Set to true to produce unique filenames where duplicate data keys exist between ConfigMaps and/or Secrets within the same or multiple Namespaces.
+  - required: false
+  - default: false
   - type: boolean
 
 - `DEFAULT_FILE_MODE`

--- a/sidecar/helpers.py
+++ b/sidecar/helpers.py
@@ -76,3 +76,19 @@ def request(url, method, payload=None):
 def timestamp():
     """Get a timestamp of the current time for logging."""
     return datetime.now().strftime("[%Y-%m-%d %X]")
+
+
+def uniqueFilename(filename, namespace, resource, resource_name):
+    """Return a unique filename derived from the arguments provided, e.g.
+    "namespace_{namespace}-{configmap|secret}_{resource_name}-{filename}".
+
+    This is used where duplicate data keys may exist between ConfigMaps
+    and/or Secrets within the same or multiple Namespaces.
+
+    Keyword arguments:
+    filename -- the filename derived from a data key present in a ConfigMap or Secret.
+    namespace -- the Namespace from which data is sourced.
+    resource -- the resource type, e.g. "configmap" or "secret".
+    resource_name -- the name of the "configmap" or "secret" resource instance.
+    """
+    return "namespace_" + namespace + "-" + resource + "_" + resource_name + "-" + filename

--- a/sidecar/helpers.py
+++ b/sidecar/helpers.py
@@ -80,7 +80,7 @@ def timestamp():
 
 def uniqueFilename(filename, namespace, resource, resource_name):
     """Return a unique filename derived from the arguments provided, e.g.
-    "namespace_{namespace}-{configmap|secret}_{resource_name}-{filename}".
+    "namespace_{namespace}.{configmap|secret}_{resource_name}.{filename}".
 
     This is used where duplicate data keys may exist between ConfigMaps
     and/or Secrets within the same or multiple Namespaces.
@@ -91,4 +91,4 @@ def uniqueFilename(filename, namespace, resource, resource_name):
     resource -- the resource type, e.g. "configmap" or "secret".
     resource_name -- the name of the "configmap" or "secret" resource instance.
     """
-    return "namespace_" + namespace + "-" + resource + "_" + resource_name + "-" + filename
+    return "namespace_" + namespace + "." + resource + "_" + resource_name + "." + filename

--- a/sidecar/resources.py
+++ b/sidecar/resources.py
@@ -179,11 +179,11 @@ def _watch_resource_loop(mode, *args):
 
 
 def watchForChanges(mode, label, labelValue, targetFolder, url, method, payload,
-                    currentNamespace, folderAnnotation, resources):
+                    currentNamespace, folderAnnotation, resources, uniqueFilenames):
 
     firstProc = Process(target=_watch_resource_loop,
                         args=(mode, label, labelValue, targetFolder, url, method, payload,
-                              currentNamespace, folderAnnotation, resources[0])
+                              currentNamespace, folderAnnotation, resources[0], uniqueFilenames)
                         )
     firstProc.daemon=True
     firstProc.start()
@@ -191,7 +191,7 @@ def watchForChanges(mode, label, labelValue, targetFolder, url, method, payload,
     if len(resources) == 2:
         secProc = Process(target=_watch_resource_loop,
                           args=(mode, label, labelValue, targetFolder, url, method, payload,
-                                currentNamespace, folderAnnotation, resources[1])
+                                currentNamespace, folderAnnotation, resources[1], uniqueFilenames)
                           )
         secProc.daemon=True
         secProc.start()

--- a/sidecar/resources.py
+++ b/sidecar/resources.py
@@ -12,7 +12,7 @@ from kubernetes import client, watch
 from kubernetes.client.rest import ApiException
 from urllib3.exceptions import ProtocolError
 
-from helpers import request, writeTextToFile, removeFile, timestamp
+from helpers import request, writeTextToFile, removeFile, timestamp, uniqueFilename
 
 _list_namespaced = {
     "secret": "list_namespaced_secret",
@@ -56,7 +56,8 @@ def _get_destination_folder(metadata, defaultFolder, folderAnnotation):
     return defaultFolder
 
 
-def listResources(label, labelValue, targetFolder, url, method, payload, currentNamespace, folderAnnotation, resource):
+def listResources(label, labelValue, targetFolder, url, method, payload,
+                  currentNamespace, folderAnnotation, resource, uniqueFilenames):
     v1 = client.CoreV1Api()
     namespace = os.getenv("NAMESPACE", currentNamespace)
     # Filter resources based on label and value or just label
@@ -86,6 +87,12 @@ def listResources(label, labelValue, targetFolder, url, method, payload, current
         for data_key in dataMap.keys():
             filename, filedata = _get_file_data_and_name(data_key, dataMap[data_key],
                                                             resource)
+            if uniqueFilenames:
+                filename = uniqueFilename(filename      = filename,
+                                          namespace     = metadata.namespace,
+                                          resource      = resource,
+                                          resource_name = metadata.name)
+
             writeTextToFile(destFolder, filename, filedata)
 
             if url:
@@ -93,7 +100,7 @@ def listResources(label, labelValue, targetFolder, url, method, payload, current
 
 
 def _watch_resource_iterator(label, labelValue, targetFolder, url, method, payload,
-                             currentNamespace, folderAnnotation, resource):
+                             currentNamespace, folderAnnotation, resource, uniqueFilenames):
     v1 = client.CoreV1Api()
     namespace = os.getenv("NAMESPACE", currentNamespace)
     # Filter resources based on label and value or just label
@@ -127,6 +134,12 @@ def _watch_resource_iterator(label, labelValue, targetFolder, url, method, paylo
             if (eventType == "ADDED") or (eventType == "MODIFIED"):
                 filename, filedata = _get_file_data_and_name(data_key, dataMap[data_key],
                                                                 resource)
+                if uniqueFilenames:
+                    filename = uniqueFilename(filename      = filename,
+                                              namespace     = metadata.namespace,
+                                              resource      = resource,
+                                              resource_name = metadata.name)
+
                 writeTextToFile(destFolder, filename, filedata)
 
                 if url:
@@ -134,6 +147,13 @@ def _watch_resource_iterator(label, labelValue, targetFolder, url, method, paylo
             else:
                 # Get filename from event
                 filename = data_key[:-4] if data_key.endswith(".url") else data_key
+
+                if uniqueFilenames:
+                    filename = uniqueFilename(filename      = filename,
+                                              namespace     = metadata.namespace,
+                                              resource      = resource,
+                                              resource_name = metadata.name)
+
                 removeFile(destFolder, filename)
                 if url:
                     request(url, method, payload)

--- a/sidecar/sidecar.py
+++ b/sidecar/sidecar.py
@@ -49,6 +49,14 @@ def main():
         configuration.debug = False
         client.Configuration.set_default(configuration)
 
+    uniqueFilenames = os.getenv("UNIQUE_FILENAMES") 
+    if uniqueFilenames is not None and uniqueFilenames.lower() == "true":
+        print(f"{timestamp()} Unique filenames will enforced.")
+        uniqueFilenames = True
+    else:
+        print(f"{timestamp()} Unique filenames will not be enforced.")
+        uniqueFilenames = False
+
     if os.getenv("METHOD") == "LIST":
         for res in resources:
             listResources(label, labelValue, targetFolder, url, method, payload,

--- a/sidecar/sidecar.py
+++ b/sidecar/sidecar.py
@@ -60,10 +60,10 @@ def main():
     if os.getenv("METHOD") == "LIST":
         for res in resources:
             listResources(label, labelValue, targetFolder, url, method, payload,
-                          currentNamespace, folderAnnotation, res)
+                          currentNamespace, folderAnnotation, res, uniqueFilenames)
     else:
         watchForChanges(os.getenv("METHOD"), label, labelValue, targetFolder, url, method,
-                        payload, currentNamespace, folderAnnotation, resources)
+                        payload, currentNamespace, folderAnnotation, resources, uniqueFilenames)
 
 
 if __name__ == "__main__":

--- a/sidecar/sidecar.py
+++ b/sidecar/sidecar.py
@@ -51,7 +51,7 @@ def main():
 
     uniqueFilenames = os.getenv("UNIQUE_FILENAMES") 
     if uniqueFilenames is not None and uniqueFilenames.lower() == "true":
-        print(f"{timestamp()} Unique filenames will enforced.")
+        print(f"{timestamp()} Unique filenames will be enforced.")
         uniqueFilenames = True
     else:
         print(f"{timestamp()} Unique filenames will not be enforced.")


### PR DESCRIPTION
# Motivation
This functionality is targeted at consumers who rely on ConfigMaps and/or Secrets within the same or across multiple Namespaces. In this scenario a risk of (un)intentional runtime data loss is present. This occurs when non-unique data keys exist between ConfigMaps, ConfigMaps and Secrets or between Secrets. The situation described becomes even more likely with the aforementioned resources when multiple Namespaces are involved.

This update introduces a new environment variable "UNIQUE_FILENAMES" which when set to "true" will result in the generation of unique filenames, e.g. "namespace_{namespace}.{configmap|secret}_{resource_name}.{filename}".

# Reproduction Steps
```
$ k create ns production
namespace/production created
$ k create ns development
namespace/development created

cat << EOF > someImportantJob.yaml
---
apiVersion: batch/v1
kind: Job
metadata:
  name: someimportantjob
  namespace: production
spec:
  template:
    metadata:
      name: someImportantJob
      namespace: monitoring-system
    spec:
      restartPolicy: OnFailure
      volumes:
      - name: configuration
        emptyDir: {}
      containers:
        - name: iconsumeconfigcapsccrosscamespaces
          image: enhariharan/infinite-loop
          volumeMounts:
          - name: configuration
            mountPath: /mnt/configuration

        - name: k8s-sidecar
          image: kiwigrid/k8s-sidecar
          imagePullPolicy: Always
          env:
            - name: LABEL
              value: "testlabel"
            - name: FOLDER
              value: "/mnt/configuration"
            - name: DEFAULT_FILE_MODE
              value: "666"
            - name: METHOD
              value: "WATCH"
            - name: NAMESPACE
              value: "ALL"

          volumeMounts:
          - name: configuration
            mountPath: /mnt/configuration
EOF
$ k create -f ./someImportantJob.yaml
job.batch/someimportantjob created

$ kns production
Context "docker-for-desktop" modified.
Active namespace is "production".

$ k get po
NAME                     READY   STATUS    RESTARTS   AGE
someimportantjob-mt2mg   2/2     Running   0          18s

$ k logs someimportantjob-mt2mg k8s-sidecar
[2020-03-17 20:50:34] Starting collector
[2020-03-17 20:50:34] No folder annotation was provided, defaulting to k8s-sidecar-target-directory
[2020-03-17 20:50:34] Selected resource type: ('configmap',)
[2020-03-17 20:50:34] Config for cluster api loaded...

$ k create -f ./production_configmap.yaml
configmap/runtime-config created

$ k logs someimportantjob-mt2mg k8s-sidecar
[2020-03-17 20:50:34] Starting collector
[2020-03-17 20:50:34] No folder annotation was provided, defaulting to k8s-sidecar-target-directory
[2020-03-17 20:50:34] Selected resource type: ('configmap',)
[2020-03-17 20:50:34] Config for cluster api loaded...
[2020-03-17 20:52:12] Working on configmap production/runtime-config
[2020-03-17 20:52:12] File in configmap important_config.yaml ADDED

$ k exec -ti someimportantjob-mt2mg sh
Defaulting container name to iconsumeconfigcapsccrosscamespaces.
Use 'kubectl describe pod/someimportantjob-mt2mg -n production' to see all of the containers in this pod.
/ # cat /mnt/configuration/important_config.yaml ; echo
service_running: true
/ #

# Introduce bad config:
$ k create -f ./development_configmap.yaml
configmap/runtime-config created

$ k logs someimportantjob-mt2mg k8s-sidecar
[2020-03-17 20:50:34] Starting collector
[2020-03-17 20:50:34] No folder annotation was provided, defaulting to k8s-sidecar-target-directory
[2020-03-17 20:50:34] Selected resource type: ('configmap',)
[2020-03-17 20:50:34] Config for cluster api loaded...
[2020-03-17 20:52:12] Working on configmap production/runtime-config
[2020-03-17 20:52:12] File in configmap important_config.yaml ADDED
[2020-03-17 20:53:54] Working on configmap development/runtime-config
[2020-03-17 20:53:54] File in configmap important_config.yaml ADDED

$ k exec -ti someimportantjob-mt2mg sh
Defaulting container name to iconsumeconfigcapsccrosscamespaces.
Use 'kubectl describe pod/someimportantjob-mt2mg -n production' to see all of the containers in this pod.
/ # cat /mnt/configuration/important_config.yaml ; echo
service_running: false
/ # ls -l /mnt/configuration/
total 4
-rw-rw-rw-    1 nobody   nobody          22 Mar 17 20:53 important_config.yaml
/ #

```

# Change Validation
```
$ k create ns production
namespace/production created
$ k create ns development
namespace/development created

$ cat << EOF > someImportantJob.yaml
---
apiVersion: batch/v1
kind: Job
metadata:
  name: someimportantjob
  namespace: production
spec:
  template:
    metadata:
      name: someImportantJob
      namespace: monitoring-system
    spec:
      restartPolicy: OnFailure
      volumes:
      - name: configuration
        emptyDir: {}
      containers:
        - name: iconsumeconfigcapsccrosscamespaces
          image: enhariharan/infinite-loop
          volumeMounts:
          - name: configuration
            mountPath: /mnt/configuration

        - name: k8s-sidecar
          image: alexandertgtalbot/k8s-sidecar:unique_filenames
          imagePullPolicy: Always
          env:
            - name: LABEL
              value: "testlabel"
            - name: FOLDER
              value: "/mnt/configuration"
            - name: DEFAULT_FILE_MODE
              value: "666"
            - name: UNIQUE_FILENAMES
              value: "true"
            - name: METHOD
              value: "WATCH"
            - name: NAMESPACE
              value: "ALL"

          volumeMounts:
          - name: configuration
            mountPath: /mnt/configuration
EOF

$ k create -f ./someImportantJob.yaml
job.batch/someimportantjob created

$ kns production
Context "docker-for-desktop" modified.
Active namespace is "production".

$ k get po
NAME                     READY   STATUS    RESTARTS   AGE
someimportantjob-jts84   2/2     Running   0          13s

$ k logs someimportantjob-jts84 k8s-sidecar
[2020-03-17 20:26:25] Starting collector
[2020-03-17 20:26:25] No folder annotation was provided, defaulting to k8s-sidecar-target-directory
[2020-03-17 20:26:25] Selected resource type: ('configmap',)
[2020-03-17 20:26:25] Config for cluster api loaded...
[2020-03-17 20:26:25] Unique filenames will be enforced.

$ k exec -ti someimportantjob-jts84 sh
Defaulting container name to iconsumeconfigcapsccrosscamespaces.
Use 'kubectl describe pod/someimportantjob-jts84 -n production' to see all of the containers in this pod.
/ # ls -l /mnt/configuration/
total 0
/ #

$ cat << EOF > production_configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: runtime-config
  namespace: production
  labels:
    testlabel: testlabel
data:
  important_config.yaml: |-
    service_running: true
EOF

$ k get cm runtime-config -n production -o yaml
Error from server (NotFound): configmaps "runtime-config" not found
$ k create -f ./production_configmap.yaml
configmap/runtime-config created
$ k get cm runtime-config -n production -o yaml
apiVersion: v1
data:
  important_config.yaml: 'service_running: true'
kind: ConfigMap
metadata:
  creationTimestamp: "2020-03-17T20:28:27Z"
  labels:
    testlabel: testlabel
  name: runtime-config
  namespace: production
  resourceVersion: "7855125"
  selfLink: /api/v1/namespaces/production/configmaps/runtime-config
  uid: db856c28-688d-11ea-906a-025000000001

$ k logs someimportantjob-jts84 k8s-sidecar
[2020-03-17 20:26:25] Starting collector
[2020-03-17 20:26:25] No folder annotation was provided, defaulting to k8s-sidecar-target-directory
[2020-03-17 20:26:25] Selected resource type: ('configmap',)
[2020-03-17 20:26:25] Config for cluster api loaded...
[2020-03-17 20:26:25] Unique filenames will be enforced.
[2020-03-17 20:28:27] Working on configmap production/runtime-config
[2020-03-17 20:28:27] File in configmap important_config.yaml ADDED

$ k exec -ti someimportantjob-jts84 sh
Defaulting container name to iconsumeconfigcapsccrosscamespaces.
Use 'kubectl describe pod/someimportantjob-jts84 -n production' to see all of the containers in this pod.
/ # ls -l /mnt/configuration/
total 4
-rw-rw-rw-    1 nobody   nobody          21 Mar 17 20:28 namespace_production.configmap_runtime-config.important_config.yaml
/ # cat /mnt/configuration/namespace_production.configmap_runtime-config.important_config.yaml
service_running: true

# Introduce a bad ConfigMap
$ cat << EOF > bad_production_configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: bad-runtime-config
  namespace: production
  labels:
    testlabel: testlabel
data:
  important_config.yaml: |-
    service_running: false
EOF
$ k create -f ./bad_production_configmap.yaml
configmap/bad-runtime-config created

$ k logs someimportantjob-jts84 k8s-sidecar
[2020-03-17 20:26:25] Starting collector
[2020-03-17 20:26:25] No folder annotation was provided, defaulting to k8s-sidecar-target-directory
[2020-03-17 20:26:25] Selected resource type: ('configmap',)
[2020-03-17 20:26:25] Config for cluster api loaded...
[2020-03-17 20:26:25] Unique filenames will be enforced.
[2020-03-17 20:28:27] Working on configmap production/runtime-config
[2020-03-17 20:28:27] File in configmap important_config.yaml ADDED
[2020-03-17 20:31:38] Working on configmap production/bad-runtime-config
[2020-03-17 20:31:38] File in configmap important_config.yaml ADDED

$ k exec -ti someimportantjob-jts84 sh
Defaulting container name to iconsumeconfigcapsccrosscamespaces.
Use 'kubectl describe pod/someimportantjob-jts84 -n production' to see all of the containers in this pod.
drwxrwxrwx    2 root     root          4096 Mar 17 20:31 configuration
/ # ls -l /mnt/configuration/
total 8
-rw-rw-rw-    1 nobody   nobody          22 Mar 17 20:31 namespace_production.configmap_bad-runtime-config.important_config.yaml
-rw-rw-rw-    1 nobody   nobody          21 Mar 17 20:28 namespace_production.configmap_runtime-config.important_config.yaml
/ #

$ cat << EOF > development_configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: runtime-config
  namespace: development
  labels:
    testlabel: testlabel
data:
  important_config.yaml: |-
    service_running: false
EOF
$ k create -f ./development_configmap.yaml
configmap/runtime-config created

$ k logs someimportantjob-jts84 k8s-sidecar
[2020-03-17 20:26:25] Starting collector
[2020-03-17 20:26:25] No folder annotation was provided, defaulting to k8s-sidecar-target-directory
[2020-03-17 20:26:25] Selected resource type: ('configmap',)
[2020-03-17 20:26:25] Config for cluster api loaded...
[2020-03-17 20:26:25] Unique filenames will be enforced.
[2020-03-17 20:28:27] Working on configmap production/runtime-config
[2020-03-17 20:28:27] File in configmap important_config.yaml ADDED
[2020-03-17 20:31:38] Working on configmap production/bad-runtime-config
[2020-03-17 20:31:38] File in configmap important_config.yaml ADDED
[2020-03-17 20:35:24] Working on configmap development/runtime-config
[2020-03-17 20:35:24] File in configmap important_config.yaml ADDED

$ k exec -ti someimportantjob-jts84 sh
Defaulting container name to iconsumeconfigcapsccrosscamespaces.
Use 'kubectl describe pod/someimportantjob-jts84 -n production' to see all of the containers in this pod.
/ # cd /mnt/configuration/
/mnt/configuration # ls -l
total 12
-rw-rw-rw-    1 nobody   nobody          22 Mar 17 20:35 namespace_development.configmap_runtime-config.important_config.yaml
-rw-rw-rw-    1 nobody   nobody          22 Mar 17 20:31 namespace_production.configmap_bad-runtime-config.important_config.yaml
-rw-rw-rw-    1 nobody   nobody          21 Mar 17 20:28 namespace_production.configmap_runtime-config.important_config.yaml
/mnt/configuration # cat *
service_running: falseservice_running: falseservice_running: true/mnt/configuration #
/mnt/configuration # for A in *; do echo $A; cat $A; echo ; done
namespace_development.configmap_runtime-config.important_config.yaml
service_running: false
namespace_production.configmap_bad-runtime-config.important_config.yaml
service_running: false
namespace_production.configmap_runtime-config.important_config.yaml
service_running: true
/mnt/configuration #

$ k create ns qa
namespace/qa created
$ k create -f ./qa_configmap.yaml
configmap/runtime-config created
$ k logs someimportantjob-jts84 k8s-sidecar
[2020-03-17 20:26:25] Starting collector
[2020-03-17 20:26:25] No folder annotation was provided, defaulting to k8s-sidecar-target-directory
[2020-03-17 20:26:25] Selected resource type: ('configmap',)
[2020-03-17 20:26:25] Config for cluster api loaded...
[2020-03-17 20:26:25] Unique filenames will be enforced.
[2020-03-17 20:28:27] Working on configmap production/runtime-config
[2020-03-17 20:28:27] File in configmap important_config.yaml ADDED
[2020-03-17 20:31:38] Working on configmap production/bad-runtime-config
[2020-03-17 20:31:38] File in configmap important_config.yaml ADDED
[2020-03-17 20:35:24] Working on configmap development/runtime-config
[2020-03-17 20:35:24] File in configmap important_config.yaml ADDED
[2020-03-17 20:39:50] Working on configmap qa/runtime-config
[2020-03-17 20:39:50] File in configmap important_config.yaml ADDED
$ k exec -ti someimportantjob-jts84 sh
Defaulting container name to iconsumeconfigcapsccrosscamespaces.
Use 'kubectl describe pod/someimportantjob-jts84 -n production' to see all of the containers in this pod.
/ # cd /mnt/configuration/
/mnt/configuration # for A in *; do echo $A; cat $A; echo ; done
namespace_development.configmap_runtime-config.important_config.yaml
service_running: false
namespace_production.configmap_bad-runtime-config.important_config.yaml
service_running: false
namespace_production.configmap_runtime-config.important_config.yaml
service_running: true
namespace_qa.configmap_runtime-config.important_config.yaml
service_running: false
/mnt/configuration #
```