### PR TITLE
Use numeric UID/GID to satisfy PSPs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ RUN         apk add --no-cache gcc && \
 
 COPY sidecar/* ./
 
-#run as non-privileged user 
-USER nobody
+# Use the nobody user's numeric UID/GID to satisfy MustRunAsNonRoot PodSecurityPolicies
+# https://kubernetes.io/docs/concepts/policy/pod-security-policy/#users-and-groups
+USER 65534:65534
+
 CMD         [ "python", "-u", "/app/sidecar.py" ]


### PR DESCRIPTION
Hey guys,

Here's another PR to make PodSecurityPolicies happy with this image - we simply use the "nobody" user's numeric UID/GID, so that the PSP Admission controller can be assured that we haven't remapped "nobody" to uid 0, for nefarious purposes!

I've tested locally on my own image, works fine :)

D