### PR TITLE
Catch MaxRetryError and wait a little

### DIFF
--- a/sidecar/resources.py
+++ b/sidecar/resources.py
@@ -147,6 +147,8 @@ def _watch_resource_loop(mode, *args):
                 listResources(*args)
                 sleep(60)
             else:
+                # Always wait 5 seconds to slow down the loop in case of exceptions
+                sleep(5)
                 _watch_resource_iterator(*args)
         except ApiException as e:
             if e.status != 500:
@@ -157,7 +159,6 @@ def _watch_resource_loop(mode, *args):
             print(f"{timestamp()} ProtocolError when calling kubernetes: {e}\n")
         except MaxRetryError as e:
             print(f"{timestamp()} MaxRetryError when calling kubernetes: {e}\n")
-            sleep(5)
         except Exception as e:
             print(f"{timestamp()} Received unknown exception: {e}\n")
 

--- a/sidecar/resources.py
+++ b/sidecar/resources.py
@@ -11,6 +11,7 @@ from time import sleep
 from kubernetes import client, watch
 from kubernetes.client.rest import ApiException
 from urllib3.exceptions import ProtocolError
+from urllib3.exceptions import MaxRetryError
 
 from helpers import request, writeTextToFile, removeFile, timestamp
 
@@ -154,6 +155,9 @@ def _watch_resource_loop(mode, *args):
                 raise
         except ProtocolError as e:
             print(f"{timestamp()} ProtocolError when calling kubernetes: {e}\n")
+        except MaxRetryError as e:
+            print(f"{timestamp()} MaxRetryError when calling kubernetes: {e}\n")
+            sleep(5)
         except Exception as e:
             print(f"{timestamp()} Received unknown exception: {e}\n")
 


### PR DESCRIPTION
I'm using k8s-sidecar with Istio and when the pod is spawn, it takes few seconds before it can connect to the API. If somehow the Istio sidecar is not working correctly, it generates hundred of log entries per seconds trying to connect to 172.20.0.1.