### PR TITLE
Prevent from request bursts

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,15 @@ If the filename ends with `.url` suffix, the content will be processed as an URL
   - type: string
 
 - `METHOD`
-  - description: If `METHOD` is set with `LIST`, the sidecar will just list config-maps and exit. With `SLEEP` it will list all config-maps, then sleep for 60 seconds. Default is watch.
+  - description: If `METHOD` is set with `LIST`, the sidecar will just list config-maps and exit. With `SLEEP` it will list all config-maps, then sleep for `SLEEP_TIME` seconds. Default is watch.
   - required: false
   - type: string
+
+- `SLEEP_TIME`
+  - description: How many seconds to wait before updating config-maps when using `SLEEP` method.
+  - required: false
+  - default: 60
+  - type: integer
 
 - `REQ_URL`
   - description: URL to which send a request after a configmap got reloaded
@@ -120,10 +126,16 @@ If the filename ends with `.url` suffix, the content will be processed as an URL
   - type: float
 
 - `REQ_TIMEOUT`
-  - description: many seconds to wait for the server to send data before giving up
+  - description: How many seconds to wait for the server to send data before giving up
   - required: false
   - default: 10
   - type: float
+
+- `ERROR_THROTTLE_SLEEP`
+  - description: How many seconds to wait before watching resources again when an error occurs
+  - required: false
+  - default: 5
+  - type: integer
 
 - `SKIP_TLS_VERIFY`
   - description: Set to true to skip tls verification for kube api calls

--- a/sidecar/resources.py
+++ b/sidecar/resources.py
@@ -72,7 +72,7 @@ def listResources(label, labelValue, targetFolder, url, method, payload,
     # For all the found resources
     for sec in ret.items:
         metadata = sec.metadata
-        
+
         print(f"{timestamp()} Working on {resource}: {metadata.namespace}/{metadata.name}")
 
         # Get the destination folder
@@ -96,8 +96,8 @@ def listResources(label, labelValue, targetFolder, url, method, payload,
 
             writeTextToFile(destFolder, filename, filedata)
 
-            if url:
-                request(url, method, payload)
+    if url:
+        request(url, method, payload)
 
 
 def _watch_resource_iterator(label, labelValue, targetFolder, url, method, payload,
@@ -115,7 +115,7 @@ def _watch_resource_iterator(label, labelValue, targetFolder, url, method, paylo
     # Process events
     for event in stream:
         metadata = event["object"].metadata
-    
+
         print(f"{timestamp()} Working on {resource} {metadata.namespace}/{metadata.name}")
 
         # Get the destination folder
@@ -142,9 +142,6 @@ def _watch_resource_iterator(label, labelValue, targetFolder, url, method, paylo
                                               resource_name = metadata.name)
 
                 writeTextToFile(destFolder, filename, filedata)
-
-                if url:
-                    request(url, method, payload)
             else:
                 # Get filename from event
                 filename = data_key[:-4] if data_key.endswith(".url") else data_key
@@ -156,19 +153,19 @@ def _watch_resource_iterator(label, labelValue, targetFolder, url, method, paylo
                                               resource_name = metadata.name)
 
                 removeFile(destFolder, filename)
-                if url:
-                    request(url, method, payload)
+        if url:
+            request(url, method, payload)
 
 
 def _watch_resource_loop(mode, *args):
     while True:
         try:
+            # Always wait to slow down the loop in case of exceptions
+            sleep(os.getenv("ERROR_THROTTLE_SLEEP", 5))
             if mode == "SLEEP":
                 listResources(*args)
-                sleep(60)
+                sleep(os.getenv("SLEEP_TIME", 60))
             else:
-                # Always wait 5 seconds to slow down the loop in case of exceptions
-                sleep(5)
                 _watch_resource_iterator(*args)
         except ApiException as e:
             if e.status != 500:


### PR DESCRIPTION
Hello there 👋

In some conditions, the sidecar may perform request bursts, especially when using the `SLEEP` mode. Therefore, I made a few tweaks:
* Avoid performing multiple successive requests for each resources
* Throttle on error when using the `SLEEP` method
* Make error throttling and `SLEEP` method sleep time configurable