### PR TITLE
Add multi-arch builds with docker buildx

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
 
       - setup_remote_docker:
           version: 19.03.12
-      #    docker_layer_caching: true
+          docker_layer_caching: true
 
       - run: |
           TAG=0.1.$CIRCLE_BUILD_NUM
@@ -122,7 +122,7 @@ jobs:
       - checkout
       - setup_remote_docker:
           version: 19.03.12
-      #    docker_layer_caching: true
+          docker_layer_caching: true
 
       - run: |
           TAG=`cat /tmp/VERSION`

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,7 +134,7 @@ jobs:
           docker context create buildcontext
           docker buildx create buildcontext --use
           docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
-          docker buildx build --push -t kiwigrid/k8s-sidecar:$TAG -t kiwigrid/k8s-sidecar:latest --platform linux/amd64,linux/arm64,linux/arm/v7 .
+          echo "FROM kiwigrid/k8s-sidecar-build:$TAG" | docker buildx build --push -t kiwigrid/k8s-sidecar:$TAG -t kiwigrid/k8s-sidecar:latest --platform linux/amd64,linux/arm64,linux/arm/v7 -
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,14 +38,22 @@ jobs:
       #    destination: test-reports
 
       - setup_remote_docker:
-          docker_layer_caching: true
+          version: 18.09.3
+      #    docker_layer_caching: true
 
       - run: |
           TAG=0.1.$CIRCLE_BUILD_NUM
           echo "$TAG" > /tmp/VERSION
-          docker build -t   kiwigrid/k8s-sidecar-build:$TAG . 
+          mkdir -vp ~/.docker/cli-plugins/
+          curl --silent -L "https://github.com/docker/buildx/releases/download/v0.4.1/buildx-v0.4.1.linux-amd64" > ~/.docker/cli-plugins/docker-buildx
+          chmod a+x ~/.docker/cli-plugins/docker-buildx
+          docker buildx version
+          docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+          docker context create buildcontext
+          docker buildx create buildcontext --use
           docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
-          docker push kiwigrid/k8s-sidecar-build:$TAG
+          docker buildx build --push -t cablespaghetti/k8s-sidecar-build:$TAG --platform linux/amd64,linux/arm64,linux/arm/v7 .
+
       - persist_to_workspace:
           root: /tmp
           paths:
@@ -131,16 +139,19 @@ jobs:
           at: /tmp/
       - checkout
       - setup_remote_docker:
-          docker_layer_caching: true
+          version: 18.09.3
+      #    docker_layer_caching: true
 
       - run: |
           TAG=`cat /tmp/VERSION`
+          mkdir -vp ~/.docker/cli-plugins/
+          curl --silent -L "https://github.com/docker/buildx/releases/download/v0.4.1/buildx-v0.4.1.linux-amd64" > ~/.docker/cli-plugins/docker-buildx
+          chmod a+x ~/.docker/cli-plugins/docker-buildx
+          docker buildx version
+          docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+          docker buildx create --use
           docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
-          docker pull kiwigrid/k8s-sidecar-build:$TAG
-          docker tag kiwigrid/k8s-sidecar-build:$TAG kiwigrid/k8s-sidecar:$TAG
-          docker tag kiwigrid/k8s-sidecar-build:$TAG kiwigrid/k8s-sidecar:latest
-          docker push kiwigrid/k8s-sidecar:$TAG
-          docker push kiwigrid/k8s-sidecar:latest
+          docker buildx build --push -t cablespaghetti/k8s-sidecar:$TAG -t cablespaghetti/k8s-sidecar:latest --platform linux/amd64,linux/arm64,linux/arm/v7 .
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,6 +153,25 @@ jobs:
           command: .circleci/test-in-cluster.sh
           no_output_timeout: 3600
 
+  test-k8s-1-19:
+    machine: true
+    environment:
+      KIND_VERSION: v0.8.1
+      K8S_VERSION: v1.19.0
+    steps:
+      - attach_workspace:
+          at: /tmp/
+      - checkout
+      - run: |
+          VERSION=`cat /tmp/VERSION`
+          sed -i 's/SIDECAR_VERSION/'"$VERSION"'/g' .circleci/test/sidecar.yaml
+          sed -i 's/CIRCLE_PROJECT_USERNAME/'"$CIRCLE_PROJECT_USERNAME"'/g' .circleci/test/sidecar.yaml
+          cat .circleci/test/sidecar.yaml
+      - run:
+          name: test-in-cluster
+          command: .circleci/test-in-cluster.sh
+          no_output_timeout: 3600
+
   deploy:
     docker:
       - image: circleci/python:3.7.8
@@ -195,6 +214,9 @@ workflows:
       - test-k8s-1-18:
           requires:
             - build
+      - test-k8s-1-19:
+          requires:
+            - build
       - deploy:
           requires:
             - test-k8s-1-14
@@ -202,6 +224,7 @@ workflows:
             - test-k8s-1-16
             - test-k8s-1-17
             - test-k8s-1-18
+            - test-k8s-1-19
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,6 @@ jobs:
 
       - setup_remote_docker:
           version: 19.03.12
-          docker_layer_caching: true
 
       - run: |
           TAG=0.1.$CIRCLE_BUILD_NUM
@@ -52,7 +51,7 @@ jobs:
           docker context create buildcontext
           docker buildx create buildcontext --use
           docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
-          docker buildx build --push -t kiwigrid/k8s-sidecar-build:$TAG --platform linux/amd64,linux/arm64,linux/arm/v7 .
+          docker buildx build --push -t ${CIRCLE_PROJECT_USERNAME}/k8s-sidecar-build:$TAG --platform linux/amd64,linux/arm64,linux/arm/v7 .
 
       - persist_to_workspace:
           root: /tmp
@@ -158,7 +157,6 @@ jobs:
       - checkout
       - setup_remote_docker:
           version: 19.03.12
-          docker_layer_caching: true
 
       - run: |
           TAG=`cat /tmp/VERSION`
@@ -170,7 +168,7 @@ jobs:
           docker context create buildcontext
           docker buildx create buildcontext --use
           docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
-          echo "FROM kiwigrid/k8s-sidecar-build:$TAG" | docker buildx build --push -t kiwigrid/k8s-sidecar:$TAG -t kiwigrid/k8s-sidecar:latest --platform linux/amd64,linux/arm64,linux/arm/v7 -
+          echo "FROM ${CIRCLE_PROJECT_USERNAME}/k8s-sidecar-build:$TAG" | docker buildx build --push -t ${CIRCLE_PROJECT_USERNAME}/k8s-sidecar:$TAG -t ${CIRCLE_PROJECT_USERNAME}/k8s-sidecar:latest --platform linux/amd64,linux/arm64,linux/arm/v7 -
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,6 +70,7 @@ jobs:
       - run: |
           VERSION=`cat /tmp/VERSION`
           sed -i 's/SIDECAR_VERSION/'"$VERSION"'/g' .circleci/test/sidecar.yaml
+          sed -i 's/CIRCLE_PROJECT_USERNAME/'"$CIRCLE_PROJECT_USERNAME"'/g' .circleci/test/sidecar.yaml
           cat .circleci/test/sidecar.yaml
       - run:
           name: test-in-cluster
@@ -88,6 +89,7 @@ jobs:
       - run: |
           VERSION=`cat /tmp/VERSION`
           sed -i 's/SIDECAR_VERSION/'"$VERSION"'/g' .circleci/test/sidecar.yaml
+          sed -i 's/CIRCLE_PROJECT_USERNAME/'"$CIRCLE_PROJECT_USERNAME"'/g' .circleci/test/sidecar.yaml
           cat .circleci/test/sidecar.yaml
       - run:
           name: test-in-cluster
@@ -106,6 +108,7 @@ jobs:
       - run: |
           VERSION=`cat /tmp/VERSION`
           sed -i 's/SIDECAR_VERSION/'"$VERSION"'/g' .circleci/test/sidecar.yaml
+          sed -i 's/CIRCLE_PROJECT_USERNAME/'"$CIRCLE_PROJECT_USERNAME"'/g' .circleci/test/sidecar.yaml
           cat .circleci/test/sidecar.yaml
       - run:
           name: test-in-cluster
@@ -124,6 +127,7 @@ jobs:
       - run: |
           VERSION=`cat /tmp/VERSION`
           sed -i 's/SIDECAR_VERSION/'"$VERSION"'/g' .circleci/test/sidecar.yaml
+          sed -i 's/CIRCLE_PROJECT_USERNAME/'"$CIRCLE_PROJECT_USERNAME"'/g' .circleci/test/sidecar.yaml
           cat .circleci/test/sidecar.yaml
       - run:
           name: test-in-cluster
@@ -142,6 +146,7 @@ jobs:
       - run: |
           VERSION=`cat /tmp/VERSION`
           sed -i 's/SIDECAR_VERSION/'"$VERSION"'/g' .circleci/test/sidecar.yaml
+          sed -i 's/CIRCLE_PROJECT_USERNAME/'"$CIRCLE_PROJECT_USERNAME"'/g' .circleci/test/sidecar.yaml
           cat .circleci/test/sidecar.yaml
       - run:
           name: test-in-cluster

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,42 @@ jobs:
           paths:
             - VERSION
 
+  test-k8s-1-14:
+    machine: true
+    environment:
+      KIND_VERSION: v0.8.1
+      K8S_VERSION: v1.14.10
+    steps:
+      - attach_workspace:
+          at: /tmp/
+      - checkout
+      - run: |
+          VERSION=`cat /tmp/VERSION`
+          sed -i 's/SIDECAR_VERSION/'"$VERSION"'/g' .circleci/test/sidecar.yaml
+          cat .circleci/test/sidecar.yaml
+      - run:
+          name: test-in-cluster
+          command: .circleci/test-in-cluster.sh
+          no_output_timeout: 3600
+
+  test-k8s-1-15:
+    machine: true
+    environment:
+      KIND_VERSION: v0.8.1
+      K8S_VERSION: v1.15.11
+    steps:
+      - attach_workspace:
+          at: /tmp/
+      - checkout
+      - run: |
+          VERSION=`cat /tmp/VERSION`
+          sed -i 's/SIDECAR_VERSION/'"$VERSION"'/g' .circleci/test/sidecar.yaml
+          cat .circleci/test/sidecar.yaml
+      - run:
+          name: test-in-cluster
+          command: .circleci/test-in-cluster.sh
+          no_output_timeout: 3600
+
   test-k8s-1-16:
     machine: true
     environment:
@@ -152,6 +188,8 @@ workflows:
             - build
       - deploy:
           requires:
+            - test-k8s-1-14
+            - test-k8s-1-15
             - test-k8s-1-16
             - test-k8s-1-17
             - test-k8s-1-18

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,6 +177,12 @@ workflows:
   test_deploy:
     jobs:
       - build
+      - test-k8s-1-14:
+          requires:
+            - build
+      - test-k8s-1-15:
+          requires:
+            - build
       - test-k8s-1-16:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: circleci/python:3.7.4
+      - image: circleci/python:3.7.8
 
     working_directory: ~/repo
 
@@ -38,7 +38,7 @@ jobs:
       #    destination: test-reports
 
       - setup_remote_docker:
-          version: 18.09.3
+          version: 19.03.12
       #    docker_layer_caching: true
 
       - run: |
@@ -133,13 +133,13 @@ jobs:
 
   deploy:
     docker:
-      - image: circleci/python:3.7.4
+      - image: circleci/python:3.7.8
     steps:
       - attach_workspace:
           at: /tmp/
       - checkout
       - setup_remote_docker:
-          version: 18.09.3
+          version: 19.03.12
       #    docker_layer_caching: true
 
       - run: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
           docker context create buildcontext
           docker buildx create buildcontext --use
           docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
-          docker buildx build --push -t cablespaghetti/k8s-sidecar-build:$TAG --platform linux/amd64,linux/arm64,linux/arm/v7 .
+          docker buildx build --push -t kiwigrid/k8s-sidecar-build:$TAG --platform linux/amd64,linux/arm64,linux/arm/v7 .
 
       - persist_to_workspace:
           root: /tmp
@@ -133,7 +133,7 @@ jobs:
           docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
           docker buildx create --use
           docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
-          docker buildx build --push -t cablespaghetti/k8s-sidecar:$TAG -t cablespaghetti/k8s-sidecar:latest --platform linux/amd64,linux/arm64,linux/arm/v7 .
+          docker buildx build --push -t kiwigrid/k8s-sidecar:$TAG -t kiwigrid/k8s-sidecar:latest --platform linux/amd64,linux/arm64,linux/arm/v7 .
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,65 +59,47 @@ jobs:
           paths:
             - VERSION
 
-  test-k8s-1-13:
-    machine: true
-    environment:
-      KIND_VERSION: v0.7.0
-      K8S_VERSION: v1.13.12
-    steps:
-      - attach_workspace:
-          at: /tmp/
-      - checkout
-      - run: |
-          VERSION=`cat /tmp/VERSION`
-          sed -i 's/SIDECAR_VERSION/'"$VERSION"'/g' .circleci/test/sidecar.yaml
-          cat .circleci/test/sidecar.yaml
-      - run:
-          name: test-in-cluster
-          command: .circleci/test-in-cluster.sh
-          no_output_timeout: 3600
-
-  test-k8s-1-14:
-    machine: true
-    environment:
-      KIND_VERSION: v0.7.0
-      K8S_VERSION: v1.14.10
-    steps:
-      - attach_workspace:
-          at: /tmp/
-      - checkout
-      - run: |
-          VERSION=`cat /tmp/VERSION`
-          sed -i 's/SIDECAR_VERSION/'"$VERSION"'/g' .circleci/test/sidecar.yaml
-          cat .circleci/test/sidecar.yaml
-      - run:
-          name: test-in-cluster
-          command: .circleci/test-in-cluster.sh
-          no_output_timeout: 3600
-
-  test-k8s-1-15:
-    machine: true
-    environment:
-      KIND_VERSION: v0.7.0
-      K8S_VERSION: v1.15.7
-    steps:
-      - attach_workspace:
-          at: /tmp/
-      - checkout
-      - run: |
-          VERSION=`cat /tmp/VERSION`
-          sed -i 's/SIDECAR_VERSION/'"$VERSION"'/g' .circleci/test/sidecar.yaml
-          cat .circleci/test/sidecar.yaml
-      - run:
-          name: test-in-cluster
-          command: .circleci/test-in-cluster.sh
-          no_output_timeout: 3600
-
   test-k8s-1-16:
     machine: true
     environment:
-      KIND_VERSION: v0.7.0
-      K8S_VERSION: v1.16.4
+      KIND_VERSION: v0.8.1
+      K8S_VERSION: v1.16.14
+    steps:
+      - attach_workspace:
+          at: /tmp/
+      - checkout
+      - run: |
+          VERSION=`cat /tmp/VERSION`
+          sed -i 's/SIDECAR_VERSION/'"$VERSION"'/g' .circleci/test/sidecar.yaml
+          cat .circleci/test/sidecar.yaml
+      - run:
+          name: test-in-cluster
+          command: .circleci/test-in-cluster.sh
+          no_output_timeout: 3600
+
+  test-k8s-1-17:
+    machine: true
+    environment:
+      KIND_VERSION: v0.8.1
+      K8S_VERSION: v1.17.11
+    steps:
+      - attach_workspace:
+          at: /tmp/
+      - checkout
+      - run: |
+          VERSION=`cat /tmp/VERSION`
+          sed -i 's/SIDECAR_VERSION/'"$VERSION"'/g' .circleci/test/sidecar.yaml
+          cat .circleci/test/sidecar.yaml
+      - run:
+          name: test-in-cluster
+          command: .circleci/test-in-cluster.sh
+          no_output_timeout: 3600
+
+  test-k8s-1-18:
+    machine: true
+    environment:
+      KIND_VERSION: v0.8.1
+      K8S_VERSION: v1.18.8
     steps:
       - attach_workspace:
           at: /tmp/
@@ -158,24 +140,20 @@ workflows:
   test_deploy:
     jobs:
       - build
-      - test-k8s-1-13:
-          requires:
-            - build
-      - test-k8s-1-14:
-          requires:
-            - build
-      - test-k8s-1-15:
-          requires:
-            - build
       - test-k8s-1-16:
+          requires:
+            - build
+      - test-k8s-1-17:
+          requires:
+            - build
+      - test-k8s-1-18:
           requires:
             - build
       - deploy:
           requires:
-            - test-k8s-1-13
-            - test-k8s-1-14
-            - test-k8s-1-15
             - test-k8s-1-16
+            - test-k8s-1-17
+            - test-k8s-1-18
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,7 +131,8 @@ jobs:
           chmod a+x ~/.docker/cli-plugins/docker-buildx
           docker buildx version
           docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-          docker buildx create --use
+          docker context create buildcontext
+          docker buildx create buildcontext --use
           docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
           docker buildx build --push -t kiwigrid/k8s-sidecar:$TAG -t kiwigrid/k8s-sidecar:latest --platform linux/amd64,linux/arm64,linux/arm/v7 .
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ jobs:
     machine: true
     environment:
       KIND_VERSION: v0.8.1
-      K8S_VERSION: v1.16.14
+      K8S_VERSION: v1.16.9
     steps:
       - attach_workspace:
           at: /tmp/
@@ -81,7 +81,7 @@ jobs:
     machine: true
     environment:
       KIND_VERSION: v0.8.1
-      K8S_VERSION: v1.17.11
+      K8S_VERSION: v1.17.5
     steps:
       - attach_workspace:
           at: /tmp/

--- a/.circleci/test-in-cluster.sh
+++ b/.circleci/test-in-cluster.sh
@@ -68,7 +68,7 @@ CLUSTER_NAME="sidecar-testing"
   }
 
   verify_configmap_read(){
-    kubectl exec sidecar ls /tmp/hello.world
+    kubectl exec sidecar -- ls /tmp/hello.world
   }
 
   cleanup_cluster() {

--- a/.circleci/test/sidecar.yaml
+++ b/.circleci/test/sidecar.yaml
@@ -34,7 +34,7 @@ spec:
   serviceAccountName: sample-acc
   containers:
   - name: sidecar
-    image: kiwigrid/k8s-sidecar-build:SIDECAR_VERSION
+    image: CIRCLE_PROJECT_USERNAME/k8s-sidecar-build:SIDECAR_VERSION
     volumeMounts:
     - name: shared-volume
       mountPath: /tmp/

--- a/.circleci/test/sidecar.yaml
+++ b/.circleci/test/sidecar.yaml
@@ -34,7 +34,7 @@ spec:
   serviceAccountName: sample-acc
   containers:
   - name: sidecar
-    image: kiwigrid/k8s-sidecar-build:SIDECAR_VERSION
+    image: cablespaghetti/k8s-sidecar-build:SIDECAR_VERSION
     volumeMounts:
     - name: shared-volume
       mountPath: /tmp/

--- a/.circleci/test/sidecar.yaml
+++ b/.circleci/test/sidecar.yaml
@@ -34,7 +34,7 @@ spec:
   serviceAccountName: sample-acc
   containers:
   - name: sidecar
-    image: cablespaghetti/k8s-sidecar-build:SIDECAR_VERSION
+    image: kiwigrid/k8s-sidecar-build:SIDECAR_VERSION
     volumeMounts:
     - name: shared-volume
       mountPath: /tmp/


### PR DESCRIPTION
Uses docker buildx to build images to arm/v7 and arm64 as well as amd64. Also updated Kubernetes versions used and the build container version.

Working pipeline (before I changed the Docker Hub image name back to yours) here: https://app.circleci.com/pipelines/github/cablespaghetti/k8s-sidecar
Resulting images here: https://hub.docker.com/r/cablespaghetti/k8s-sidecar

~~I have had to rebuild on the deploy step as I'm not sure of a way to pull and re-push the whole manifest list.~~ (see comment below)
I've also not tested with docker_layer_caching enabled as this isn't on the free plan of Circle CI. But I don't imagine this makes a big difference.

Closes #48 