### PR TITLE
BUGFIX: Setting env variables SLEEP_TIME or ERROR_THROTTLE_SLEEP raises exceptions

### DIFF
--- a/sidecar/resources.py
+++ b/sidecar/resources.py
@@ -161,10 +161,10 @@ def _watch_resource_loop(mode, *args):
     while True:
         try:
             # Always wait to slow down the loop in case of exceptions
-            sleep(os.getenv("ERROR_THROTTLE_SLEEP", 5))
+            sleep(int(os.getenv("ERROR_THROTTLE_SLEEP", 5)))
             if mode == "SLEEP":
                 listResources(*args)
-                sleep(os.getenv("SLEEP_TIME", 60))
+                sleep(int(os.getenv("SLEEP_TIME", 60)))
             else:
                 _watch_resource_iterator(*args)
         except ApiException as e:


### PR DESCRIPTION
```
[2020-09-01 13:44:55] Received unknown exception: an integer is required (got type str)
```
`sleep()` expects int but `os.getenv()` returns string (unless the default value is used) 


To reproduce:
1) set `SLEEP_TIME` or `ERROR_THROTTLE_SLEEP`
2) run the sidecar