### PR TITLE
Improve versioning and tagging releases

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,11 @@
 FROM        python:3.7-slim
+#create app directory
 WORKDIR     /app
 COPY        requirements.txt .
 RUN         pip install -r requirements.txt
 COPY        sidecar/* ./
 ENV         PYTHONUNBUFFERED=1
+
+#run as non-privileged user 
+USER nobody
 CMD         [ "python", "-u", "/app/sidecar.py" ]


### PR DESCRIPTION
Previously the git tags were set manually, now a github action sets them and circleci uses the tag when available. Fixes #87 