### PR TITLE
Upgrade docker base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM        python:3.7-alpine
+FROM        python:3.8-alpine
 ENV         PYTHONUNBUFFERED=1
 WORKDIR     /app
 


### PR DESCRIPTION
The reason for this PR is to remove the security vulnerabilities found in the docker image.

Currently, anchore reports the following vulnerabilities:

```
$ anchore-cli image vuln docker.io/kiwigrid/k8s-sidecar:1.3.0 all
Vulnerability ID        Package                       Severity        Fix               CVE Refs        Vulnerability URL                                                   Type        Feed Group         Package Path        
CVE-2020-28928          musl-1.1.24-r9                Low             1.1.24-r10                        http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-28928        APKG        alpine:3.12        pkgdb               
CVE-2020-28928          musl-utils-1.1.24-r9          Low             1.1.24-r10                        http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-28928        APKG        alpine:3.12        pkgdb               
CVE-2020-1971           libcrypto1.1-1.1.1g-r0        Medium          1.1.1i-r0                         http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-1971         APKG        alpine:3.12        pkgdb               
CVE-2020-1971           libssl1.1-1.1.1g-r0           Medium          1.1.1i-r0                         http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-1971         APKG        alpine:3.12        pkgdb               
CVE-2020-28196          krb5-libs-1.18.2-r0           Medium          1.18.3-r0                         http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-28196        APKG        alpine:3.12        pkgdb               
```

After the upgrade, the reported vulnerabilities drops to 0.