### PR TITLE
Ensure that quay.io image is still multi-arch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -214,10 +214,11 @@ jobs:
           docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
           docker context create buildcontext
           docker buildx create buildcontext --use
-          echo $DOCKER_PASSWORD   | docker login -u $DOCKER_USERNAME   --password-stdin docker.io
+          echo "${DOCKER_PASSWORD}" | docker login --username="${DOCKER_USERNAME}" --password-stdin docker.io
           echo "FROM ${CIRCLE_PROJECT_USERNAME}/k8s-sidecar-build:$TAG" \
             | docker buildx build \
             --push \
+            --progress plain \
             --tag docker.io/${CIRCLE_PROJECT_USERNAME}/k8s-sidecar:$TAG \
             --tag docker.io/${CIRCLE_PROJECT_USERNAME}/k8s-sidecar:latest \
             --platform linux/amd64,linux/arm64,linux/arm/v7 \

--- a/README.md
+++ b/README.md
@@ -16,6 +16,15 @@ Currently (April 2018) there is no simple way to hand files in configmaps to a s
 Run the container created by this repo together with your application in an single pod with a shared volume. Specify which label should be monitored and where the files should be stored.
 By adding additional env variables the container can send an HTTP request to specified URL.
 
+# Where?
+
+Images are available at:
+
+- [docker.io/kiwigrid/k8s-sidecar](https://hub.docker.com/r/kiwigrid/k8s-sidecar)
+- [quay.io/kiwigrid/k8s-sidecar](https://quay.io/repository/kiwigrid/k8s-sidecar)
+
+Both are identical multi-arch images built for `amd64`, `arm64` and `arm/v7`
+
 # Features
 
 - Extract files from config maps


### PR DESCRIPTION
Unfortunately the change to avoid a docker buildx bug has also meant that the quay.io version of the image is amd64 only. There doesn't seem to be any good tooling for replicating the multi-arch manifest list but I've implemented it in bash.

My test quay.io repository: https://quay.io/repository/cablespaghetti/k8s-sidecar?tab=tags
Pipeline of my most recent commit: https://app.circleci.com/pipelines/github/cablespaghetti/k8s-sidecar/58/workflows/b114b950-42e3-402e-a7bc-3bc55a50fe91

Thanks!