### PR TITLE
Allow folder annotation paths to be relative or absolute

### DIFF
--- a/.circleci/test-in-cluster.sh
+++ b/.circleci/test-in-cluster.sh
@@ -88,11 +88,15 @@ KIND_CONFIG="${CWD}/kind-config.yaml"
     kubectl cp sidecar:/tmp/cm-kubelogo.png /tmp/cm-kubelogo.png
     kubectl cp sidecar:/tmp/secret-kubelogo.png /tmp/secret-kubelogo.png
     kubectl cp sidecar:/tmp/script_result /tmp/script_result
+    kubectl cp sidecar:/tmp/absolute/absolute.txt /tmp/absolute.txt
+    kubectl cp sidecar:/tmp/relative/relative.txt /tmp/relative.txt
     
     log "Verifying file content..."
     echo -n "Hello World!" | diff - /tmp/hello.world \
       && diff ${CWD}/kubelogo.png /tmp/cm-kubelogo.png \
       && diff ${CWD}/kubelogo.png /tmp/secret-kubelogo.png \
+      && echo -n "This absolutely exists" | diff - /tmp/absolute.txt \
+      && echo -n "This relatively exists" | diff - /tmp/relative.txt \
       && ls /tmp/script_result
   }
 

--- a/.circleci/test/resources.yaml
+++ b/.circleci/test/resources.yaml
@@ -29,3 +29,27 @@ data:
   script.sh: |-
      #!/bin/sh
      touch /tmp/script_result
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: absolute-configmap
+  labels:
+    findme: "yup"
+  annotations:
+    k8s-sidecar-target-directory: /tmp/absolute/
+data:
+  absolute.txt: |-
+     This absolutely exists
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: relative-configmap
+  labels:
+    findme: "yup"
+  annotations:
+    k8s-sidecar-target-directory: relative
+data:
+  relative.txt: |-
+     This relatively exists

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ If the filename ends with `.url` suffix, the content will be processed as an URL
   - type: string
 
 - `FOLDER_ANNOTATION`
-  - description: The annotation the sidecar will look for in configmaps to override the destination folder for files, defaults to "k8s-sidecar-target-directory"
+  - description: The annotation the sidecar will look for in configmaps to override the destination folder for files, defaults to "k8s-sidecar-target-directory". The annotation _value_ can be either an absolute or a relative path. Relative paths will be relative to `FOLDER`.
   - required: false
   - type: string
 

--- a/sidecar/resources.py
+++ b/sidecar/resources.py
@@ -54,7 +54,11 @@ def _get_file_data_and_name(full_filename, content, content_type=CONTENT_TYPE_TE
 
 def _get_destination_folder(metadata, default_folder, folder_annotation):
     if metadata.annotations and folder_annotation in metadata.annotations.keys():
-        dest_folder = metadata.annotations[folder_annotation]
+        folder_annotation = metadata.annotations[folder_annotation]
+        if os.path.isabs(folder_annotation):
+            dest_folder = folder_annotation
+        else:
+            dest_folder = os.path.join(default_folder, folder_annotation)
         print(f"{timestamp()} Found a folder override annotation, "
               f"placing the {metadata.name} in: {dest_folder}")
         return dest_folder


### PR DESCRIPTION
This allows the FOLDER annotation to take a relative path (relative to the default folder) which makes usage with the Grafana helm chart a lot cleaner. This would close #101 