### PR TITLE
Feature flag `URL_REFRESH_INTERVAL` for update of url content #major

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ If the filename ends with `.url` suffix, the content will be processed as an URL
   - required: false
   - type: boolean
 
-- `DYNAMIC_URL`
-  - description: Set to true to enable a dynamic update of *.url content from config map. Used in case if the filename ends with `.url` suffix (Please refer to the `*.url` feature here.)
+- `URL_REFRESH_INTERVAL`
+  - description: Set with integer value of seconds, where 0 means `once`. set value `> 0` to enable a dynamic update with refresh interval `URL_REFRESH_INTERVAL` of *.url content from config map. Used in case if the filename ends with `.url` suffix (Please refer to the `*.url` feature here.)
   - required: false
-  - type: boolean
+  - type: integer

--- a/README.md
+++ b/README.md
@@ -176,3 +176,8 @@ If the filename ends with `.url` suffix, the content will be processed as an URL
   - description: Set to true to enable pulling of 5XX response content from config map. Used in case if the filename ends with `.url` suffix (Please refer to the `*.url` feature here.)
   - required: false
   - type: boolean
+
+- `DYNAMIC_URL`
+  - description: Set to true to enable a dynamic update of *.url content from config map. Used in case if the filename ends with `.url` suffix (Please refer to the `*.url` feature here.)
+  - required: false
+  - type: boolean

--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ If the filename ends with `.url` suffix, the content will be processed as an URL
   - type: boolean
 
 - `URL_REFRESH_INTERVAL`
-  - description: Set with integer value of seconds, where 0 means `once`. set value `> 0` to enable a dynamic update with refresh interval `URL_REFRESH_INTERVAL` of *.url content from config map. Used in case if the filename ends with `.url` suffix (Please refer to the `*.url` feature here.)
+  - description: How often to refresh the content of `.url` entries in seconds, where 0 means `once`.
   - required: false
+  - default: 0
   - type: integer

--- a/sidecar/helpers.py
+++ b/sidecar/helpers.py
@@ -46,6 +46,8 @@ def write_data_to_file(folder, filename, data, data_type=CONTENT_TYPE_TEXT):
         if sha256_hash_new.hexdigest() == sha256_hash_cur.hexdigest():
             print(f"{timestamp()} Contents of {filename} haven't changed. Not overwriting existing file")
             return False
+        else:
+            print(f"{timestamp()} Contents of {filename} changed. overwriting existing file {absolute_path}")
 
     if data_type == "binary":
         write_type = "wb"

--- a/sidecar/sidecar.py
+++ b/sidecar/sidecar.py
@@ -66,16 +66,18 @@ def main():
         print(f"{timestamp()} Unique filenames will not be enforced.")
         unique_filenames = False
 
+    url_refresh_interval = os.getenv(URL_REFRESH_INTERVAL)
+
     try:
-        url_refresh_interval = int(os.getenv(URL_REFRESH_INTERVAL))
+        if url_refresh_interval is not None:
+            url_refresh_interval = int(url_refresh_interval)
+            print(f"{timestamp()} dynamic_url content reload will be enabled. Refresh interval {url_refresh_interval}")
+        else:
+            print(f"{timestamp()} dynamic_url content reload will not be enabled.")
+            url_refresh_interval = None
     except ValueError:
         print(f"{timestamp()} cannot convert {URL_REFRESH_INTERVAL} to integer! Exit")
         return -1
-    if (url_refresh_interval is not None) or (url_refresh_interval != 0):
-        print(f"{timestamp()} dynamic_url content reload will be enabled. Refresh interval {url_refresh_interval}")
-    else:
-        print(f"{timestamp()} dynamic_url content reload will not be enabled.")
-        url_refresh_interval = None
 
     enable_5xx = os.getenv(ENABLE_5XX)
     if enable_5xx is not None and enable_5xx.lower() == "true":

--- a/sidecar/sidecar.py
+++ b/sidecar/sidecar.py
@@ -21,6 +21,7 @@ REQ_URL = "REQ_URL"
 REQ_METHOD = "REQ_METHOD"
 SCRIPT = "SCRIPT"
 ENABLE_5XX = "ENABLE_5XX"
+DYNAMIC_URL = "DYNAMIC_URL"
 
 
 def main():
@@ -65,6 +66,14 @@ def main():
         print(f"{timestamp()} Unique filenames will not be enforced.")
         unique_filenames = False
 
+    dynamic_url = os.getenv(DYNAMIC_URL)
+    if dynamic_url is not None and dynamic_url.lower() == "true":
+        print(f"{timestamp()} dynamic_url content reload will be enabled.")
+        dynamic_url = True
+    else:
+        print(f"{timestamp()} dynamic_url content reload will not be enabled.")
+        dynamic_url = False
+
     enable_5xx = os.getenv(ENABLE_5XX)
     if enable_5xx is not None and enable_5xx.lower() == "true":
         print(f"{timestamp()} 5xx response content will be enabled.")
@@ -79,7 +88,7 @@ def main():
             list_resources(label, label_value, target_folder, url, method, payload,
                            current_namespace, folder_annotation, res, unique_filenames, script, enable_5xx)
     else:
-        watch_for_changes(os.getenv(METHOD), label, label_value, target_folder, url, method, payload,
+        watch_for_changes(os.getenv(METHOD), dynamic_url, label, label_value, target_folder, url, method, payload,
                           current_namespace, folder_annotation, resources, unique_filenames, script, enable_5xx)
 
 

--- a/sidecar/sidecar.py
+++ b/sidecar/sidecar.py
@@ -66,9 +66,13 @@ def main():
         print(f"{timestamp()} Unique filenames will not be enforced.")
         unique_filenames = False
 
-    url_refresh_interval = os.getenv(URL_REFRESH_INTERVAL)
-    if url_refresh_interval is not None or url_refresh_interval != 0:
-        print(f"{timestamp()} dynamic_url content reload will be enabled. with refresh interval {url_refresh_interval}")
+    try:
+        url_refresh_interval = int(os.getenv(URL_REFRESH_INTERVAL))
+    except ValueError:
+        print(f"{timestamp()} cannot convert {URL_REFRESH_INTERVAL} to integer! Exit")
+        return -1
+    if (url_refresh_interval is not None) or (url_refresh_interval != 0):
+        print(f"{timestamp()} dynamic_url content reload will be enabled. Refresh interval {url_refresh_interval}")
     else:
         print(f"{timestamp()} dynamic_url content reload will not be enabled.")
         url_refresh_interval = None

--- a/sidecar/sidecar.py
+++ b/sidecar/sidecar.py
@@ -66,18 +66,14 @@ def main():
         print(f"{timestamp()} Unique filenames will not be enforced.")
         unique_filenames = False
 
-    url_refresh_interval = os.getenv(URL_REFRESH_INTERVAL)
-
     try:
-        if url_refresh_interval is not None:
-            url_refresh_interval = int(url_refresh_interval)
-            print(f"{timestamp()} dynamic_url content reload will be enabled. Refresh interval {url_refresh_interval}")
-        else:
-            print(f"{timestamp()} dynamic_url content reload will not be enabled.")
-            url_refresh_interval = None
+        url_refresh_interval = int(os.getenv(URL_REFRESH_INTERVAL, 0))
     except ValueError:
         print(f"{timestamp()} cannot convert {URL_REFRESH_INTERVAL} to integer! Exit")
         return -1
+
+    if url_refresh_interval > 0:
+        print(f"{timestamp()} '.url' content refreshing will be enabled. Refresh interval {url_refresh_interval}")
 
     enable_5xx = os.getenv(ENABLE_5XX)
     if enable_5xx is not None and enable_5xx.lower() == "true":

--- a/sidecar/sidecar.py
+++ b/sidecar/sidecar.py
@@ -21,7 +21,7 @@ REQ_URL = "REQ_URL"
 REQ_METHOD = "REQ_METHOD"
 SCRIPT = "SCRIPT"
 ENABLE_5XX = "ENABLE_5XX"
-DYNAMIC_URL = "DYNAMIC_URL"
+URL_REFRESH_INTERVAL = "URL_REFRESH_INTERVAL"
 
 
 def main():
@@ -66,13 +66,12 @@ def main():
         print(f"{timestamp()} Unique filenames will not be enforced.")
         unique_filenames = False
 
-    dynamic_url = os.getenv(DYNAMIC_URL)
-    if dynamic_url is not None and dynamic_url.lower() == "true":
-        print(f"{timestamp()} dynamic_url content reload will be enabled.")
-        dynamic_url = True
+    url_refresh_interval = os.getenv(URL_REFRESH_INTERVAL)
+    if url_refresh_interval is not None or url_refresh_interval != 0:
+        print(f"{timestamp()} dynamic_url content reload will be enabled. with refresh interval {url_refresh_interval}")
     else:
         print(f"{timestamp()} dynamic_url content reload will not be enabled.")
-        dynamic_url = False
+        url_refresh_interval = None
 
     enable_5xx = os.getenv(ENABLE_5XX)
     if enable_5xx is not None and enable_5xx.lower() == "true":
@@ -88,8 +87,9 @@ def main():
             list_resources(label, label_value, target_folder, url, method, payload,
                            current_namespace, folder_annotation, res, unique_filenames, script, enable_5xx)
     else:
-        watch_for_changes(os.getenv(METHOD), dynamic_url, label, label_value, target_folder, url, method, payload,
-                          current_namespace, folder_annotation, resources, unique_filenames, script, enable_5xx)
+        watch_for_changes(os.getenv(METHOD), url_refresh_interval, label, label_value,
+                          target_folder, url, method, payload, current_namespace, folder_annotation,
+                          resources, unique_filenames, script, enable_5xx)
 
 
 def _initialize_kubeclient_configuration():


### PR DESCRIPTION
- introduced new flag for dynamic update from *.url endpoints
- new process spawn for watching changes to *.url content dynamically
- update file on shared volume if content is updated at endpoint
- `URL_REFRESH_INTERVAL` default value is `0` - no dynamic refresh of url 
- value `>0`, the urls are dynamically updated with refresh interval of seconds `URL_REFRESH_INTERVAL` 

Use Case 
- the files created from `*.url` are currently static, in case the content at endpoint is changed then this watcher will keep the files updated in the volume
 - can be used as a dynamic backend for ambassador ingress serving custom error pages from endpoints