### PR TITLE
bump requests to 2.25.1 to fix CVE-2021-33503 in urllib3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 kubernetes==12.0.0
-requests==2.24.0
+requests==2.25.1


### PR DESCRIPTION
Good morning folks

As already mentioned in https://github.com/kiwigrid/k8s-sidecar/issues/126, the latest docker image `kiwigrid/k8s-sidecar:1.12.0` contains the following security vulnerabilities in its dependencies:
- pip-21.0.1: [CVE-2021-3572](https://security-tracker.debian.org/tracker/CVE-2021-3572)
- urllib3-1.25.11: [CVE-2021-33503](https://www.cybersecurity-help.cz/vdb/SB2021061305)

(according to [whitesource](https://www.whitesourcesoftware.com/resources/blog/docker-image-security-scanning/) which is used internally in our company)


Merging the PR fixes both CVEs:

- pip is already bumped to `21.1.2` in upstream `python:3.8-alpine`. So a simple rebuild of the docker image will fix that issue (and is actually unrelated to my PR).
- bumping `requests` to latest `2.25.1` will allow transitive dependency `urllib3` to be updated to the latest `1.26.5`,  because [`requests` `2.25.0` introduced support of `urllib3 > 1.16`](https://github.com/psf/requests/blob/master/HISTORY.md#2250-2020-11-11).

Let me know if we can support further to fix this!