### PR TITLE
Update helpers.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ If the filename ends with `.url` suffix, the content will be processed as an URL
 - `REQ_RETRY_CONNECT`
   - description: How many connection-related errors to retry on
   - required: false
-  - default: 5
+  - default: 10
   - type: integer
 
 - `REQ_RETRY_READ`
@@ -131,7 +131,7 @@ If the filename ends with `.url` suffix, the content will be processed as an URL
 - `REQ_RETRY_BACKOFF_FACTOR`
   - description: A backoff factor to apply between attempts after the second try
   - required: false
-  - default: 0.2
+  - default: 1.1
   - type: float
 
 - `REQ_TIMEOUT`

--- a/sidecar/helpers.py
+++ b/sidecar/helpers.py
@@ -73,10 +73,10 @@ def remove_file(folder, filename):
 
 def request(url, method, enable_5xx=False, payload=None):
     retry_total = 5 if os.getenv("REQ_RETRY_TOTAL") is None else int(os.getenv("REQ_RETRY_TOTAL"))
-    retry_connect = 5 if os.getenv("REQ_RETRY_CONNECT") is None else int(
+    retry_connect = 10 if os.getenv("REQ_RETRY_CONNECT") is None else int(
         os.getenv("REQ_RETRY_CONNECT"))
     retry_read = 5 if os.getenv("REQ_RETRY_READ") is None else int(os.getenv("REQ_RETRY_READ"))
-    retry_backoff_factor = 0.2 if os.getenv("REQ_RETRY_BACKOFF_FACTOR") is None else float(
+    retry_backoff_factor = 1.1 if os.getenv("REQ_RETRY_BACKOFF_FACTOR") is None else float(
         os.getenv("REQ_RETRY_BACKOFF_FACTOR"))
     timeout = 10 if os.getenv("REQ_TIMEOUT") is None else float(os.getenv("REQ_TIMEOUT"))
     enforce_status_codes = list() if enable_5xx else [500, 502, 503, 504]


### PR DESCRIPTION
Fixes #76 

Docs https://urllib3.readthedocs.io/en/latest/reference/urllib3.util.html — basically, having 0.25 eats the five retries way too quickly, especially when it comes to connecting the socket over a network that might take a few seconds to establish the TCP connection.

Relevant docs:

> A backoff factor to apply between attempts after the second try (most errors are resolved immediately by a second try without a delay). urllib3 will sleep for:
> `{backoff factor} * (2 ** ({number of total retries} - 1))`
> seconds. If the backoff_factor is 0.1, then sleep() will sleep for [0.0s, 0.2s, 0.4s, …] between retries. It will never be longer than Retry.BACKOFF_MAX.
> By default, backoff is disabled (set to 0).