### PR TITLE
Docker image - update python to v3.9 #patch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM        python:3.8-alpine
+FROM        python:3.9-alpine
 ENV         PYTHONUNBUFFERED=1
 WORKDIR     /app
 


### PR DESCRIPTION
Security scans report [CVE-2021-29921](https://nvd.nist.gov/vuln/detail/CVE-2021-29921), it no longer appears when python:3.9-alpine is used.