### PR TITLE
Add support for ppc64le architecture

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,7 +47,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/ppc64le
           tags: |
             docker.io/kiwigrid/k8s-sidecar:latest
             docker.io/kiwigrid/k8s-sidecar:${{ steps.tagging.outputs.tag }}

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Images are available at:
 - [docker.io/kiwigrid/k8s-sidecar](https://hub.docker.com/r/kiwigrid/k8s-sidecar)
 - [quay.io/kiwigrid/k8s-sidecar](https://quay.io/repository/kiwigrid/k8s-sidecar)
 
-Both are identical multi-arch images built for `amd64`, `arm64` and `arm/v7`
+Both are identical multi-arch images built for `amd64`, `arm64`, `arm/v7` and `ppc64le`
 
 # Features
 


### PR DESCRIPTION
This PR enables github actions to also build ppc64le images.