### PR TITLE
Fix CVE-2022-43680

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apk add --no-cache gcc && \
 	.venv/bin/pip install --no-cache-dir -r requirements.txt && \
     rm requirements.txt && \
 	find /app/.venv \( -type d -a -name test -o -name tests \) -o \( -type f -a -name '*.pyc' -o -name '*.pyo' \) -exec rm -rf '{}' \+
-
+RUN apk add --upgrade expat
 
 FROM base
 ENV         PYTHONUNBUFFERED=1


### PR DESCRIPTION
Fixing expat v2.4.9-r0 to latest by adding an `apk add --upgrade expat` after installing python requirements.

fixes CVE-2022-43680: https://avd.aquasec.com/nvd/2022/cve-2022-43680/