### PR TITLE
try to parse `REQ_PAYLOAD` as json to avoid unexpected quoting

### DIFF
--- a/src/helpers.py
+++ b/src/helpers.py
@@ -109,7 +109,6 @@ def remove_file(folder, filename):
         logger.error(f"Unable to remove {complete_file}, file not found")
         return False
 
-
 def request(url, method, enable_5xx=False, payload=None):
     enforce_status_codes = list() if enable_5xx else [500, 502, 503, 504]
 
@@ -139,7 +138,7 @@ def request(url, method, enable_5xx=False, payload=None):
     if method == "GET" or not method:
         res = r.get("%s" % url, auth=auth, timeout=REQ_TIMEOUT, verify=REQ_TLS_VERIFY)
     elif method == "POST":
-        res = r.post("%s" % url, auth=auth, json=json.loads(payload), timeout=REQ_TIMEOUT, verify=REQ_TLS_VERIFY)
+        res = r.post("%s" % url, auth=auth, json=payload, timeout=REQ_TIMEOUT, verify=REQ_TLS_VERIFY)
     else:
         logger.warning(f"Invalid REQ_METHOD: '{method}', please use 'GET' or 'POST'. Doing nothing.")
         return

--- a/src/helpers.py
+++ b/src/helpers.py
@@ -139,7 +139,7 @@ def request(url, method, enable_5xx=False, payload=None):
     if method == "GET" or not method:
         res = r.get("%s" % url, auth=auth, timeout=REQ_TIMEOUT, verify=REQ_TLS_VERIFY)
     elif method == "POST":
-        res = r.post("%s" % url, auth=auth, json=payload, timeout=REQ_TIMEOUT, verify=REQ_TLS_VERIFY)
+        res = r.post("%s" % url, auth=auth, json=json.loads(payload), timeout=REQ_TIMEOUT, verify=REQ_TLS_VERIFY)
     else:
         logger.warning(f"Invalid REQ_METHOD: '{method}', please use 'GET' or 'POST'. Doing nothing.")
         return

--- a/src/helpers.py
+++ b/src/helpers.py
@@ -109,6 +109,7 @@ def remove_file(folder, filename):
         logger.error(f"Unable to remove {complete_file}, file not found")
         return False
 
+
 def request(url, method, enable_5xx=False, payload=None):
     enforce_status_codes = list() if enable_5xx else [500, 502, 503, 504]
 

--- a/src/resources.py
+++ b/src/resources.py
@@ -57,12 +57,12 @@ signal.signal(signal.SIGTERM, signal_handler)
 
 def prepare_payload(payload):
     """Prepare payload as dict for request."""
-    logger.debug(f"fbrousse testing.")
     try:
        payload_dict = json.loads(payload)
+       return payload_dict
     except ValueError as err:
+        logger.warning(f"Payload will be posted as quoted json")
         return payload
-    return payload_dict
 
 def _get_file_data_and_name(full_filename, content, enable_5xx, content_type=CONTENT_TYPE_TEXT):
     if content_type == CONTENT_TYPE_BASE64_BINARY:

--- a/src/resources.py
+++ b/src/resources.py
@@ -6,6 +6,7 @@ import os
 import signal
 import sys
 import traceback
+import json
 from collections import defaultdict
 from multiprocessing import Process
 from time import sleep
@@ -54,6 +55,14 @@ def signal_handler(signum, frame):
 
 signal.signal(signal.SIGTERM, signal_handler)
 
+def prepare_payload(payload):
+    """Prepare payload as dict for request."""
+    logger.debug(f"fbrousse testing.")
+    try:
+       payload_dict = json.loads(payload)
+    except ValueError as err:
+        return payload
+    return payload_dict
 
 def _get_file_data_and_name(full_filename, content, enable_5xx, content_type=CONTENT_TYPE_TEXT):
     if content_type == CONTENT_TYPE_BASE64_BINARY:

--- a/src/sidecar.py
+++ b/src/sidecar.py
@@ -60,7 +60,10 @@ def main():
 
     request_method = os.getenv(REQ_METHOD)
     request_url = os.getenv(REQ_URL)
-    request_payload = prepare_payload(os.getenv(REQ_PAYLOAD))
+   
+    request_payload = os.getenv(REQ_PAYLOAD)
+    if request_payload:
+        request_payload = prepare_payload(os.getenv(REQ_PAYLOAD))
     script = os.getenv(SCRIPT)
 
     _initialize_kubeclient_configuration()

--- a/src/sidecar.py
+++ b/src/sidecar.py
@@ -60,7 +60,7 @@ def main():
 
     request_method = os.getenv(REQ_METHOD)
     request_url = os.getenv(REQ_URL)
-    request_payload = os.getenv(REQ_PAYLOAD)
+    request_payload = prepare_payload(os.getenv(REQ_PAYLOAD))
     script = os.getenv(SCRIPT)
 
     _initialize_kubeclient_configuration()


### PR DESCRIPTION
the post method converts the json to string. Here we read from a os.environ and thus a string. So we send a string converted to string. It adds extra quotes and breaks for some server implementation (seen with grafana for provisioning). With the fix here we convert first the payload to dict to get it in the right format.