### PR TITLE
Fix missing import method for payload

### DIFF
--- a/src/sidecar.py
+++ b/src/sidecar.py
@@ -10,7 +10,7 @@ from requests.packages.urllib3.util.retry import Retry
 
 from helpers import REQ_RETRY_TOTAL, REQ_RETRY_CONNECT, REQ_RETRY_READ, REQ_RETRY_BACKOFF_FACTOR
 from logger import get_logger
-from resources import list_resources, watch_for_changes
+from resources import list_resources, watch_for_changes, prepare_payload
 
 METHOD = "METHOD"
 UNIQUE_FILENAMES = "UNIQUE_FILENAMES"


### PR DESCRIPTION
An import is missing leading to 

│ Traceback (most recent call last):                                                                                                                                                                              │
│   File "/app/sidecar.py", line 158, in <module>                                                                                                                                                                 │
│     main()                                                                                                                                                                                                      │
│   File "/app/sidecar.py", line 66, in main                                                                                                                                                                      │
│     request_payload = prepare_payload(os.getenv(REQ_PAYLOAD))                                                                                                                                                   │
│                       ^^^^^^^^^^^^^^^                                                                                                                                                                           │
│ NameError: name 'prepare_payload' is not defined