### PR TITLE
fix test for execute permission of script file

### DIFF
--- a/src/helpers.py
+++ b/src/helpers.py
@@ -172,8 +172,7 @@ def unique_filename(filename, namespace, resource, resource_name):
 def execute(script_path):
     logger.debug(f"Executing script from {script_path}")
     try:
-        file_stat = os.stat(script_path)
-        if file_stat.st_mode & stat.S_IXOTH:
+        if os.access(script_path, os.X_OK):
             result = subprocess.run([script_path],
                                     capture_output=True,
                                     check=True)

--- a/src/helpers.py
+++ b/src/helpers.py
@@ -170,7 +170,7 @@ def unique_filename(filename, namespace, resource, resource_name):
 
 
 def execute(script_path):
-    logger.debug(f"Executing script from {script_path}")
+    logger.info(f"Executing script from {script_path}")
     try:
         if os.access(script_path, os.X_OK):
             result = subprocess.run([script_path],


### PR DESCRIPTION
This PR resolves the following issues:

- Executable check does not correctly identify when the user has execute permission on the script (S_IXOTH only checks "execute/search permission, others" ie group, not the owner)
- Change log level of execute handler logger to info: resolves lack of visibility on script execution