### PR TITLE
Support resource deletion with LIST(SLEEP)

### DIFF
--- a/src/resources.py
+++ b/src/resources.py
@@ -147,10 +147,13 @@ def list_resources(label, label_value, target_folder, request_url, request_metho
 
         logger.debug(f"Removing {resource}: {metadata.namespace}/{metadata.name}")
 
+        # Get the destination folder
+        dest_folder = _get_destination_folder(metadata, target_folder, folder_annotation)
+
         if resource == RESOURCE_CONFIGMAP:
-            files_changed |= _process_config_map(None, item, resource, unique_filenames, enable_5xx, True)
+            files_changed |= _process_config_map(dest_folder, item, resource, unique_filenames, enable_5xx, True)
         else:
-            files_changed = _process_secret(None, item, resource, unique_filenames, enable_5xx, True)
+            files_changed = _process_secret(dest_folder, item, resource, unique_filenames, enable_5xx, True)
 
     if script and files_changed:
         execute(script)


### PR DESCRIPTION
This is related to issue - https://github.com/kiwigrid/k8s-sidecar/issues/311.
There is bug when the resource is deleted with method - SLEEP.

ERROR:
```
Traceback (most recent call last):
  File "/app/resources.py", line 300, in _update_file
    return remove_file(dest_folder, filename)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/helpers.py", line 103, in remove_file
    complete_file = os.path.join(folder, filename)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen posixpath>", line 76, in join
TypeError: expected str, bytes or os.PathLike object, not NoneType
```