### PR TITLE
#minor Remove unnecessary sleep before each watch cycle

### DIFF
--- a/src/resources.py
+++ b/src/resources.py
@@ -365,8 +365,6 @@ def _watch_resource_iterator(label, label_value, target_folder, request_url, req
 def _watch_resource_loop(mode, *args):
     while True:
         try:
-            # Always wait to slow down the loop in case of exceptions
-            sleep(int(os.getenv("ERROR_THROTTLE_SLEEP", 5)))
             if mode == "SLEEP":
                 list_resources(*args)
                 sleep(int(os.getenv("SLEEP_TIME", 60)))
@@ -379,11 +377,14 @@ def _watch_resource_loop(mode, *args):
                 raise
         except ProtocolError as e:
             logger.error(f"ProtocolError when calling kubernetes: {e}\n")
+            sleep(int(os.getenv("ERROR_THROTTLE_SLEEP", 5)))
         except MaxRetryError as e:
             logger.error(f"MaxRetryError when calling kubernetes: {e}\n")
+            sleep(int(os.getenv("ERROR_THROTTLE_SLEEP", 5)))
         except Exception as e:
             logger.error(f"Received unknown exception: {e}\n")
             traceback.print_exc()
+            sleep(int(os.getenv("ERROR_THROTTLE_SLEEP", 5)))
 
 
 def watch_for_changes(mode, label, label_value, target_folder, request_url, request_method, request_payload,


### PR DESCRIPTION
During my work with this project I've discovered that some DELETE k8s events are skipped for unknown reason. 
After some digging, I've managed to discover that if a DELETE event is sent while sidecar in its 5 seconds sleep between watch cycles, this event is simply gets skipped. There's no one to receive it. And after ERROR_THROTTLE_SLEEP seconds watch cycle starts, receives all modified and added k8s resources, but it doesn't get any events about deleted stuff.
And sidecar lacks a reconciliation loop to handle deleted resources based on received list of resources.

By shifting sleep throttle to only exceptions case we should manage to catch _most_ of the DELETE events.  