### PR TITLE
Stay on python stable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12.2-alpine3.19 as base
+FROM python:3.12-alpine as base
 
 FROM base as builder
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13.0a4-alpine3.18 as base
+FROM python:3.12.2-alpine3.19 as base
 
 FROM base as builder
 WORKDIR /app


### PR DESCRIPTION
It seems like python is NOT using semver for they images and dependabot is [too stupid](https://github.com/kiwigrid/k8s-sidecar/pull/323) and offers an Alpha version of python here.

Instead, dependabot will not update the alpine version. It seems like dependabot does not help here.

An potential alternative would be `python:3.12-alpine`