### PR TITLE
fixing 'as' and 'FROM' keywords' casing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM python:alpine3.20 as base
+FROM python:alpine3.20 AS base
 
-FROM base as builder
+FROM base AS builder
 WORKDIR /app
 RUN python -m venv .venv && .venv/bin/pip install --no-cache-dir -U pip setuptools
 COPY        src/ /app/


### PR DESCRIPTION
The 'as' keyword should match the case of the 'from' keyword

More info: https://docs.docker.com/go/dockerfile/rule/from-as-casing/