### PR TITLE
add DEFAULT_BRANCH variable to github-tag-action env

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 name: Release
 on:
   push:
@@ -15,6 +17,7 @@ jobs:
         uses: anothrNick/github-tag-action@1.59.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DEFAULT_BRANCH: master
           INITIAL_VERSION: 1.0.0
           DEFAULT_BUMP: none
           BRANCH_HISTORY: last


### PR DESCRIPTION
seems that anothrNick/github-tag-action needs DEFAULT_BRANCH: master in env