### PR TITLE
upgrade python:alpine3.20 to python:alpine3.21 to fix vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:alpine3.20 AS base
+FROM python:alpine3.21 AS base
 
 FROM base AS builder
 WORKDIR /app


### PR DESCRIPTION
alpine3.21 change log (https://git.alpinelinux.org/aports/log):
expat: security upgrade to 2.6.4 (https://git.alpinelinux.org/aports/commit/?id=5cc1a60c393c7ed2b6d4b82542f0595b6f6d0f65)
openssl: patch CVE-2024-9143 (https://git.alpinelinux.org/aports/commit/?id=88f7343df9d849f302eb9dbb55c97bff75a268ea)

upgrade python:alpine3.20 to python:alpine3.21 to fix vulnerabilities