### PR TITLE
Logging improvements

### DIFF
--- a/src/helpers.py
+++ b/src/helpers.py
@@ -169,13 +169,13 @@ def request(url, method, enable_5xx=False, payload=None):
     # If method is not provided use GET as default
     if method == "GET" or not method:
         res = r.get("%s" % url, auth=auth, timeout=REQ_TIMEOUT, verify=REQ_TLS_VERIFY)
+        logger.info(f"Request sent to {url}." f"Response: {res.status_code} {res.reason} {res.text}")
     elif method == "POST":
         res = r.post("%s" % url, auth=auth, json=payload, timeout=REQ_TIMEOUT, verify=REQ_TLS_VERIFY)
+        logger.info(f"{payload} sent to {url}." f"Response: {res.status_code} {res.reason} {res.text}")
     else:
         logger.warning(f"Invalid REQ_METHOD: '{method}', please use 'GET' or 'POST'. Doing nothing.")
         return
-    logger.debug(f"{method} request sent to {url}. "
-                 f"Response: {res.status_code} {res.reason} {res.text}")
     return res
 
 

--- a/src/sidecar.py
+++ b/src/sidecar.py
@@ -49,7 +49,7 @@ def main():
 
     folder_annotation = os.getenv(FOLDER_ANNOTATION)
     if folder_annotation is None:
-        logger.warning("No folder annotation was provided, "
+        logger.info("No folder annotation was provided, "
                        "defaulting to k8s-sidecar-target-directory")
         folder_annotation = "k8s-sidecar-target-directory"
 
@@ -167,7 +167,7 @@ def _initialize_kubeclient_configuration():
                                   backoff_factor=REQ_RETRY_BACKOFF_FACTOR)
     client.Configuration.set_default(configuration)
 
-    logger.info(f"Config for cluster api at '{configuration.host}' loaded...")
+    logger.info(f"Config for cluster api at '{configuration.host}' loaded.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
* Sending URL request need a log Info event: Requiring debug log level to see url request is either unhelpful or too noisy. Also mirrors script running log event.
* When logging of url request "None" was reported if defaulting to GET method.
* Useful to see payload in event on POST.
* Removal of ellipsis in config load.
* A missing, non-mandatory, option (folder annotation) shouldn't result in a warning.