### PR TITLE
Fix CVE-2025-6965 by upgrading sqlite-libs in base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM python:alpine3.22 AS base
+RUN apk update && apk upgrade sqlite-libs
 
 FROM base AS builder
 WORKDIR /app


### PR DESCRIPTION
CVE-2025-6965
  Info: https://security.snyk.io/vuln/SNYK-ALPINE322-SQLITE-10872094
  Introduced through: sqlite/sqlite-libs@3.49.2-r0, .python-rundeps@20250612.224411
  From: sqlite/sqlite-libs@3.49.2-r0
  From: .python-rundeps@20250612.224411 > sqlite/sqlite-libs@3.49.2-r0
  Fixed in: 3.49.2-r1

Upgrade sqlite-libs in the base alpine3.22 image to fix this High vulnerability