### PR TITLE
Fix file deletes in SLEEP mode

### DIFF
--- a/src/resources.py
+++ b/src/resources.py
@@ -194,6 +194,7 @@ def _process_secret(dest_folder, secret, resource, unique_filenames, enable_5xx,
     old_secret = _resources_object_map[resource].get(secret.metadata.namespace + secret.metadata.name) or copy.deepcopy(secret)
     old_dest_folder = _resources_dest_folder_map[resource].get(secret.metadata.namespace + secret.metadata.name) or dest_folder
     if is_removed:
+        dest_folder = old_dest_folder
         _resources_object_map[resource].pop(secret.metadata.namespace + secret.metadata.name, None)
     else:
         _resources_object_map[resource][secret.metadata.namespace + secret.metadata.name] = copy.deepcopy(secret)
@@ -234,6 +235,7 @@ def _process_config_map(dest_folder, config_map, resource, unique_filenames, ena
     old_config_map = _resources_object_map[resource].get(config_map.metadata.namespace + config_map.metadata.name) or copy.deepcopy(config_map)
     old_dest_folder = _resources_dest_folder_map[resource].get(config_map.metadata.namespace + config_map.metadata.name) or dest_folder
     if is_removed:
+        dest_folder = old_dest_folder
         _resources_object_map[resource].pop(config_map.metadata.namespace + config_map.metadata.name, None)
     else:
         _resources_object_map[resource][config_map.metadata.namespace + config_map.metadata.name] = copy.deepcopy(config_map)


### PR DESCRIPTION
When running k8s-sidecar in sleep mode if a configmap or secret is removed, k8s-sidecar logs the following message:

```
{"time": "2025-10-07T10:58:13.578900+00:00", "level": "ERROR", 
"msg": "Error when updating from 'mimir-custom-alerts.yaml' into 'None'", 
"exc_info": "Traceback (most recent call last):\n  File \"/app/resources.py\", line 329, in _update_file\n
    return remove_file(dest_folder, filename)\n  File \"/app/helpers.py\", line 110, in remove_file\n
    complete_file = os.path.join(folder, filename)\n  File \"<frozen posixpath>\", line 77, in join\n
TypeError: expected str, bytes or os.PathLike object, not NoneType"}
```

This #patch should fix the issue by using `old_dest_folder` instead of `dest_folder` when we're removing files. 