### PR TITLE
fix(ci): Disable pydantic binary for s390x build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,12 @@ WORKDIR /app
 RUN python -m venv .venv && .venv/bin/pip install --no-cache-dir -U pip setuptools
 COPY        src/ /app/
 RUN apk add --no-cache gcc && \
-	.venv/bin/pip install --no-cache-dir -r requirements.txt && \
+    if [ "$TARGETARCH" = "s390x" ]; then \
+        echo "s390x detected, installing pydantic without binary." && \
+        PYDANTIC_NO_BINARY=1 .venv/bin/pip install --no-cache-dir -r requirements.txt; \
+    else \
+        .venv/bin/pip install --no-cache-dir -r requirements.txt; \
+    fi && \
     rm requirements.txt && \
 	find /app/.venv \( -type d -a -name test -o -name tests \) -o \( -type f -a -name '*.pyc' -o -name '*.pyo' \) -exec rm -rf '{}' \+
 


### PR DESCRIPTION
**Analysis of the problem**

The problem is very specific and only occurs with the `s390x` architecture. Here's what happens:

1. `fastapi` requires `pydantic` as a dependency

1. `pydantic` tries to install `pydantic-core`, a component written in Rust that provides better performance

1. There is no pre-built package (no “wheel”) for the `s390x` architecture on Alpine Linux (`s390x-unknown-linux-musl`)

1. Therefore, `pip` attempts to compile `pydantic-core` from source code

1. The compilation process for Rust code (`maturin`) attempts to install the Rust toolchain, but fails because the Rust installer (`rustup`) does not support the `s390x` architecture on Alpine

**The solution**

The simplest and most targeted solution is to instruct `pydantic` to dispense with the Rust component and run in pure Python mode instead. This is performant enough for a sidecar container and solves the compilation problem for `s390x` without affecting the other architectures.

We achieve this by setting an environment variable `PYDANTIC_NO_BINARY=1`, but **only** for the `s390x` build.