### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -1,6 +1,8 @@
 ---
   # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json 
 name: "Build and Test"
+permissions:
+  contents: read
 on:
   - pull_request
   - workflow_dispatch


### PR DESCRIPTION
Potential fix for [https://github.com/kiwigrid/k8s-sidecar/security/code-scanning/1](https://github.com/kiwigrid/k8s-sidecar/security/code-scanning/1)

To fix the problem, add a top-level `permissions` key to the workflow. This should appear before the `jobs:` key and after the name/on keys in the YAML. For most build/test workflows that do *not* need to make repository changes, the safest minimal permissions are `contents: read`. If steps require additional permissions (like opening pull requests, writing deployments), those can be granted specifically.

For this workflow, none of the steps (build, test, artifact upload/download, docker, kind, etc.) appear to require write access to repo contents, issues, or PRs, and most standard actions listed work with minimal permissions. Therefore, adding `permissions: contents: read` at the root is correct.

**What to change:**  
- In the file `.github/workflows/build_and_test.yaml`, add:
  ```yaml
  permissions:
    contents: read
  ```
  after the workflow name (`name: "Build and Test"`) and before the `on:` or immediately after `on:` (YAML keys order does not impact semantics).

No new imports, methods, or definitions are needed: this is a YAML metadata change only.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
