### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/close_inactive_issues.yaml
+++ b/.github/workflows/close_inactive_issues.yaml
@@ -5,6 +5,10 @@ on:
 
 jobs:
   close-issues:
+    permissions:
+      issues: write
+      pull-requests: write
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v10


### PR DESCRIPTION
Potential fix for [https://github.com/kiwigrid/k8s-sidecar/security/code-scanning/6](https://github.com/kiwigrid/k8s-sidecar/security/code-scanning/6)

The best way to fix this is to add an explicit `permissions` block specifying only the permissions necessary for `actions/stale` to mark issues and pull-requests as stale and close them. According to the recommendation and the needs of `actions/stale`, the required minimum permissions are: `issues: write` and `pull-requests: write` (for closing and marking issues/PRs), and `contents: read` (safe default for code access in most cases). This block should be added at the job level (under `close-issues:` and above `runs-on: ...`) or the workflow level (above `jobs:`); however, adding it to the job is the recommended pattern so that different jobs in the workflow can have different permissions in the future if needed.

You only need to edit the job definition in `.github/workflows/close_inactive_issues.yaml`, adding the `permissions:` block to the `close-issues:` job, immediately after line 7, indented appropriately. No changes to other regions of the workflow or other files are necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
