### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,6 +7,9 @@ on:
       - master
 jobs:
   build:
+    permissions:
+      contents: write
+      packages: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
Potential fix for [https://github.com/kiwigrid/k8s-sidecar/security/code-scanning/4](https://github.com/kiwigrid/k8s-sidecar/security/code-scanning/4)

To fix the problem, add a `permissions` block to the workflow or job, specifying the minimal necessary privileges. Given that many steps in the workflow interact with contents and create releases, we need at least `contents: write` for pushing tags and creating releases, and possibly `packages: write` if publishing Docker images to GitHub Container Registry (ghcr.io). For tightest scoping, `permissions` should be set at the job level if only that job requires the access.

The best approach for this workflow is to add the following permissions block directly under the `build:` job (after line 9), allowing the workflow steps to push tags, create releases, and publish to ghcr.io while limiting unnecessary access:
```yaml
permissions:
  contents: write
  packages: write
```
This restricts the job’s GITHUB_TOKEN to only the necessary scopes. If push or release related actions require additional permissions (like `pull-requests: write`), those can be added later, but contents/packages should suffice for this typical release flow.

Edit file: `.github/workflows/release.yaml`
Insert the `permissions` block under the `build:` job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
