### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release_test.yaml
+++ b/.github/workflows/release_test.yaml
@@ -1,6 +1,8 @@
 ---
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 name: Release Workflow Tests
+permissions:
+  contents: write
 # This workflow tests the tag and changelog action and can be used to detect (some) breaking changes.
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/kiwigrid/k8s-sidecar/security/code-scanning/3](https://github.com/kiwigrid/k8s-sidecar/security/code-scanning/3)

**General approach:**  
Add a `permissions` section to the workflow, ideally at the top/root level so it applies to all jobs, and only grant the minimum required privileges.

**Detailed fix:**  
- Insert a `permissions:` block after the workflow name and before `on:` (or, equivalently, above `jobs:` if preferred).
- Determine the minimum set of permissions needed:
  - The workflow pushes tags, creates releases, and likely needs to write to repository contents and release information.
  - At minimum, `contents: write` is necessary for tag/release actions, and likely `pull-requests: read` or similar (but not strictly required for this workflow).
- For simplicity and minimal privilege escalation, use:
  ```yaml
  permissions:
    contents: write
  ```
  (Can expand as needed if, e.g., pull-requests or other scopes are necessary.)

**Files/regions to edit:**  
- `.github/workflows/release_test.yaml`, immediately after `name: Release Workflow Tests` (line 3), before `on:` (line 5).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
