### PR TITLE
fix: pin python version to 3.13.11 in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.14.2-alpine3.23 AS base
+FROM python:3.13.11-alpine3.23@sha256:51b5354ed44df6e1a3b3faf6d3a3d40da129621046b6d5a707b7c1f44d258ed6 AS base
 
 FROM base AS builder
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:alpine3.22 AS base
+FROM python:3.14.2-alpine3.23 AS base
 
 FROM base AS builder
 WORKDIR /app


### PR DESCRIPTION
Pins the image to a specific python version (3.13.11) and bumps to the newer alpine 3.23. Also pins to a digest.

This got "unpinned" in [this PR](https://github.com/kiwigrid/k8s-sidecar/pull/354), potentially by accident since the python and alpine tags were similar?

Related to https://github.com/kiwigrid/k8s-sidecar/issues/427