### PR TITLE
feat: Use threads instead of processes for watchers

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -444,29 +444,3 @@ jobs:
           check_empty_or_missing /tmp/sidecar-5xx/500.txt
           # Optional: Check logs for error messages.
           check_log_contains "Max retries exceeded for URL" /tmp/logs/sidecar.log
-      - name: Verify liveness probe on watcher process failure
-        shell: bash
-        run: |
-          source /tmp/sidecar_helpers.sh
-          echo "--- Verifying liveness probe ---"
-          initial_restarts=$(kubectl get pod sidecar-healthcheck -o jsonpath='{.status.containerStatuses[0].restartCount}')
-          echo "Initial restart count for 'sidecar-healthcheck' pod: $initial_restarts"
-
-          echo "Killing watcher process inside 'sidecar' pod..."
-          # The watcher processes run _watch_resource_loop. We kill one of them.
-          # The main process is PID 1, the watchers are its children. We kill all children of PID 1.
-          kubectl exec sidecar-healthcheck -- pkill -P 1
-
-          echo "Waiting for liveness probe to fail and container to restart..."
-          for i in {1..20}; do
-            current_restarts=$(kubectl get pod sidecar-healthcheck -o jsonpath='{.status.containerStatuses[0].restartCount}' || echo "$initial_restarts")
-            if [ "$current_restarts" -gt "$initial_restarts" ]; then
-              echo "Container successfully restarted. Restart count is now $current_restarts."
-              exit 0
-            fi
-            echo "Waited $((i*5)) seconds. Current restarts: $current_restarts. Waiting..."
-            sleep 5
-          done
-
-          echo "Error: Timed out waiting for container to restart. Liveness probe did not trigger a restart as expected."
-          exit 1

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ readinessProbe:
 The endpoint also serves as a liveness probe, checking for two conditions:
 
 1. Kubernetes API Contact: It verifies that the sidecar has had successful contact with the Kubernetes API within the last 60 seconds.
-1. Watcher Processes: It ensures that all internal watcher subprocesses (for `ConfigMap`s and `Secret`s) are running correctly.
+1. Watcher Threads: It ensures that all internal watcher threads (for `ConfigMap`s and `Secret`s) are running correctly.
 
 If any of these checks fail, the endpoint will return `HTTP 503 Service Unavailable`, signaling Kubernetes to restart the container.
 

--- a/src/healthz.py
+++ b/src/healthz.py
@@ -41,9 +41,9 @@ def healthz():
     if (now - last_k8s_contact) > timedelta(seconds=K8S_CONTACT_THRESHOLD_SECONDS):
         return PlainTextResponse("NOT LIVE (K8s contact lost)", status_code=503)
  
-    # Check liveness of watcher processes
+    # Check liveness of watcher threads
     if watcher_processes and not all(p.is_alive() for p in watcher_processes):
-        return PlainTextResponse("NOT LIVE (watcher process died)", status_code=503)
+        return PlainTextResponse("NOT LIVE (watcher thread died)", status_code=503)
  
     return PlainTextResponse("OK", status_code=200)
 
@@ -65,7 +65,7 @@ def update_k8s_contact():
 
 def register_watcher_processes(processes: List[Process]):
     """
-    Register the list of watcher processes to be monitored for liveness.
+    Register the list of watcher threads to be monitored for liveness.
     """
     global watcher_processes
     watcher_processes = processes

--- a/src/resources.py
+++ b/src/resources.py
@@ -8,7 +8,7 @@ import sys
 import traceback
 import json
 from collections import defaultdict
-from multiprocessing import Process
+from threading import Thread
 from time import sleep
 
 from kubernetes import client, watch
@@ -472,7 +472,7 @@ def _start_watcher_processes(namespace, folder_annotation, label, label_value, r
     processes = []
     for resource in resources:
         for ns in namespace.split(','):
-            proc = Process(target=_watch_resource_loop,
+            proc = Thread(target=_watch_resource_loop,
                            args=(mode, label, label_value, target_folder, request_url, request_method, request_payload,
                                  ns, folder_annotation, resource, unique_filenames, script, enable_5xx,
                                  ignore_already_processed, resource_name)


### PR DESCRIPTION
Replaces multiprocessing.Process with threading.Thread for watching Kubernetes resources.

This significantly reduces memory consumption, as threads are much more lightweight than processes. The savings are proportional to the number of watched resources.