### PR TITLE
CVE-2025-8869 FIX: Update Python base image to alpine3.23

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:alpine3.22 AS base
+FROM python:alpine3.23 AS base
 
 FROM base AS builder
 WORKDIR /app


### PR DESCRIPTION
fixing CVE-2025-8869

pip version needs to be 25.3