### PR TITLE
set no host so health server responds on both ipv4 and ipv6 interfaces

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -197,7 +197,7 @@ jobs:
           kubectl get pods
           wait_for_pod_ready "sidecar"
           wait_for_pod_ready "sidecar-healthcheck"
-          wait_for_pod_log "sidecar-healthcheck" "Starting health server on 0.0.0.0:8888"
+          wait_for_pod_log "sidecar-healthcheck" "Starting health server on port 8888"
           wait_for_pod_ready "sidecar-basicauth-args"
           wait_for_pod_ready "sidecar-5xx"
           wait_for_pod_ready "sidecar-pythonscript"
@@ -366,7 +366,7 @@ jobs:
         run: |
           source /tmp/sidecar_helpers.sh
           echo "--- Verifying health server startup in pod sidecar-healthcheck ---"
-          check_log_contains "Starting health server on 0.0.0.0:8888" /tmp/logs/sidecar-healthcheck.log
+          check_log_contains "Starting health server on port 8888" /tmp/logs/sidecar-healthcheck.log
       - name: Verify sidecar-basicauth-args pod file after initial sync
         shell: bash
         run: |

--- a/src/healthz.py
+++ b/src/healthz.py
@@ -128,10 +128,10 @@ def start_health_server():
         logging.config.dictConfig(log_config)
 
         health_port = int(os.getenv("HEALTH_PORT", "8080"))
-        server = ThreadingHTTPServer(("0.0.0.0", health_port), HealthHandler)
+        server = ThreadingHTTPServer(("", health_port), HealthHandler)
 
         logging.getLogger("health_server").info(
-            "Starting health server on 0.0.0.0:%d", health_port
+            "Starting health server on port %d", health_port
         )
 
         try:


### PR DESCRIPTION
Remove host from healthserver config so it will listen on all interfaces.

Fixes IPv6 issues mentioned in #507 