### PR TITLE
feat: Add parallel security scanning for container images with Dockle and Trivy

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -12,7 +12,7 @@ Security updates are provided for the latest version of the project.
 
 ## Reporting a Vulnerability
 
-If you discover a security vulnerability, please report it to us privately by visiting the [Security tab](https://github.com/kiwigrid/k8s-sidecar/security) and clicking on **"Report a vulnerability"**.
+If you discover a security vulnerability, please report it to us privately by visiting the [Security tab](https://github.com/naishy/k8s-sidecar/security) and clicking on **"Report a vulnerability"**.
 
 **Please do not create a public GitHub issue.**
 

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -3,6 +3,8 @@
 name: "Build and Test"
 permissions:
   contents: read
+  issues: write
+  pull-requests: write
 on:
   - pull_request
   - workflow_dispatch
@@ -76,7 +78,7 @@ jobs:
             echo "low=0" >> $GITHUB_OUTPUT
           fi
       - name: Post security scan results to PR
-        if: always() && github.event_name == 'pull_request'
+        if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -39,11 +39,6 @@ jobs:
           format: 'sarif'
           output: 'trivy-results.sarif'
           severity: 'CRITICAL,HIGH'
-      - name: Upload Trivy results to GitHub Security
-        uses: github/codeql-action/upload-sarif@b612e9be6c0c5eafe543bd1e46e1fc2e9b0c34e2 # v3.29.0
-        if: always()
-        with:
-          sarif_file: 'trivy-results.sarif'
       - name: Run Trivy vulnerability scanner (JSON output)
         id: trivy-scan
         uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2 # v0.28.0

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -19,7 +19,7 @@ jobs:
         with:
           push: false
           outputs: type=docker,dest=/tmp/k8s-sidecar.tar
-          tags: "kiwigrid/k8s-sidecar:testing"
+          tags: "naishy/k8s-sidecar:testing"
       - name: Prepare dummy server static resources
         run: |
           cp test/kubelogo.png test/server/static/
@@ -30,6 +30,149 @@ jobs:
           push: false
           outputs: type=docker,dest=/tmp/dummy-server.tar
           tags: "dummy-server:1.0.0"
+      - name: Load image for scanning
+        run: docker load --input /tmp/k8s-sidecar.tar
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2 # v0.28.0
+        with:
+          image-ref: 'naishy/k8s-sidecar:testing'
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          severity: 'CRITICAL,HIGH'
+      - name: Upload Trivy results to GitHub Security
+        uses: github/codeql-action/upload-sarif@b612e9be6c0c5eafe543bd1e46e1fc2e9b0c34e2 # v3.29.0
+        if: always()
+        with:
+          sarif_file: 'trivy-results.sarif'
+      - name: Run Trivy vulnerability scanner (JSON output)
+        id: trivy-scan
+        uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2 # v0.28.0
+        continue-on-error: true
+        with:
+          image-ref: 'naishy/k8s-sidecar:testing'
+          format: 'json'
+          output: 'trivy-results.json'
+          severity: 'CRITICAL,HIGH'
+      - name: Run Trivy vulnerability scanner (table output)
+        uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2 # v0.28.0
+        continue-on-error: true
+        with:
+          image-ref: 'naishy/k8s-sidecar:testing'
+          format: 'table'
+          severity: 'CRITICAL,HIGH'
+      - name: Parse vulnerability counts
+        id: parse-vulns
+        if: always()
+        run: |
+          if [ -f "trivy-results.json" ]; then
+            CRITICAL=$(jq '[.Results[]?.Vulnerabilities[]? | select(.Severity == "CRITICAL")] | length' trivy-results.json 2>/dev/null || echo "0")
+            HIGH=$(jq '[.Results[]?.Vulnerabilities[]? | select(.Severity == "HIGH")] | length' trivy-results.json 2>/dev/null || echo "0")
+            MEDIUM=$(jq '[.Results[]?.Vulnerabilities[]? | select(.Severity == "MEDIUM")] | length' trivy-results.json 2>/dev/null || echo "0")
+            LOW=$(jq '[.Results[]?.Vulnerabilities[]? | select(.Severity == "LOW")] | length' trivy-results.json 2>/dev/null || echo "0")
+            echo "critical=$CRITICAL" >> $GITHUB_OUTPUT
+            echo "high=$HIGH" >> $GITHUB_OUTPUT
+            echo "medium=$MEDIUM" >> $GITHUB_OUTPUT
+            echo "low=$LOW" >> $GITHUB_OUTPUT
+            echo "Found: $CRITICAL critical, $HIGH high, $MEDIUM medium, $LOW low"
+          else
+            echo "critical=0" >> $GITHUB_OUTPUT
+            echo "high=0" >> $GITHUB_OUTPUT
+            echo "medium=0" >> $GITHUB_OUTPUT
+            echo "low=0" >> $GITHUB_OUTPUT
+          fi
+      - name: Post security scan results to PR
+        if: always() && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- k8s-sidecar-security-scan -->';
+            
+            const critical = '${{ steps.parse-vulns.outputs.critical }}';
+            const high = '${{ steps.parse-vulns.outputs.high }}';
+            const medium = '${{ steps.parse-vulns.outputs.medium }}';
+            const low = '${{ steps.parse-vulns.outputs.low }}';
+            
+            const totalIssues = parseInt(critical) + parseInt(high);
+            const scanPassed = totalIssues === 0;
+            const statusIcon = scanPassed ? '✅' : '❌';
+            const statusText = scanPassed ? 'Passed' : 'Failed';
+            
+            let vulnDetails = '';
+            if (!scanPassed && fs.existsSync('trivy-results.json')) {
+              const trivyResults = JSON.parse(fs.readFileSync('trivy-results.json', 'utf8'));
+              const vulns = [];
+              
+              for (const result of (trivyResults.Results || [])) {
+                if (result.Vulnerabilities) {
+                  for (const vuln of result.Vulnerabilities) {
+                    if (vuln.Severity === 'CRITICAL' || vuln.Severity === 'HIGH') {
+                      vulns.push(vuln);
+                    }
+                  }
+                }
+              }
+              
+              if (vulns.length > 0) {
+                vulnDetails = '\n\n<details>\n<summary>🔍 Vulnerability Details</summary>\n\n';
+                vulnDetails += '| ID | Severity | Package | Installed | Fixed | Title |\n';
+                vulnDetails += '|-----|----------|---------|-----------|-------|-------|\n';
+                
+                for (const vuln of vulns.slice(0, 20)) {
+                  const severity = vuln.Severity === 'CRITICAL' ? '🔴 CRITICAL' : '🟠 HIGH';
+                  const cveId = vuln.VulnerabilityID;
+                  const cveLink = cveId.startsWith('CVE-') ? `[${cveId}](https://nvd.nist.gov/vuln/detail/${cveId})` : cveId;
+                  const fixedVer = vuln.FixedVersion || 'Not fixed';
+                  const title = (vuln.Title || 'N/A').substring(0, 80);
+                  vulnDetails += `| ${cveLink} | ${severity} | ${vuln.PkgName} | ${vuln.InstalledVersion} | ${fixedVer} | ${title} |\n`;
+                }
+                
+                if (vulns.length > 20) {
+                  vulnDetails += `\n*Showing 20 of ${vulns.length} vulnerabilities*\n`;
+                }
+                vulnDetails += '\n</details>\n';
+              }
+            }
+            
+            const body = `${marker}
+            ### 🔍 Security Scan Results
+            
+            | Status | Critical | High | Medium | Low |
+            |--------|----------|------|--------|-----|
+            | ${statusIcon} ${statusText} | ${critical} | ${high} | ${medium} | ${low} |
+            ${vulnDetails}
+            ---
+            [View Workflow Run](${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}) | [View Security Tab](${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/security/code-scanning)
+            `;
+            
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            
+            const existing = comments.find(c => c.body.includes(marker));
+            
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: body
+              });
+            }
+      - name: Fail if vulnerabilities found
+        if: steps.parse-vulns.outputs.critical != '0' || steps.parse-vulns.outputs.high != '0'
+        run: |
+          echo "❌ Found ${{ steps.parse-vulns.outputs.critical }} critical and ${{ steps.parse-vulns.outputs.high }} high severity vulnerabilities"
+          exit 1
       - name: Upload artifacts
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,21 +39,6 @@ jobs:
         if: steps.tagging.outputs.part != '' && steps.tagging.outputs.part != 'none'
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
-      - name: Login to DockerHub
-        if: steps.tagging.outputs.part != '' && steps.tagging.outputs.part != 'none'
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Login to Quay.io
-        if: steps.tagging.outputs.part != '' && steps.tagging.outputs.part != 'none'
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
-        with:
-          registry: quay.io
-          username: ${{ secrets.QUAY_BOT_USERNAME }}
-          password: ${{ secrets.QUAY_BOT_PASSWORD }}
-
       - name: Login to ghcr.io
         if: steps.tagging.outputs.part != '' && steps.tagging.outputs.part != 'none'
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
@@ -71,12 +56,12 @@ jobs:
           provenance: true
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           tags: |
-            docker.io/kiwigrid/k8s-sidecar:latest
-            docker.io/kiwigrid/k8s-sidecar:${{ steps.tagging.outputs.new_tag }}
-            quay.io/kiwigrid/k8s-sidecar:latest
-            quay.io/kiwigrid/k8s-sidecar:${{ steps.tagging.outputs.new_tag }}
-            ghcr.io/kiwigrid/k8s-sidecar:latest
-            ghcr.io/kiwigrid/k8s-sidecar:${{ steps.tagging.outputs.new_tag }}
+            docker.io/naishy/k8s-sidecar:latest
+            docker.io/naishy/k8s-sidecar:${{ steps.tagging.outputs.new_tag }}
+            quay.io/naishy/k8s-sidecar:latest
+            quay.io/naishy/k8s-sidecar:${{ steps.tagging.outputs.new_tag }}
+            ghcr.io/naishy/k8s-sidecar:latest
+            ghcr.io/naishy/k8s-sidecar:${{ steps.tagging.outputs.new_tag }}
 
       - name: Build Changelog
         if: steps.tagging.outputs.part != '' && steps.tagging.outputs.part != 'none'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,11 +4,8 @@ name: Release
 
 on:
   push:
-    branches:
-      - master
-    paths:
-      - 'src/**'
-      - 'Dockerfile'
+    tags:
+      - 'v*'
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -23,24 +20,22 @@ jobs:
         with:
           fetch-depth: '0'
 
-      - name: Bump version and push tag
-        id: tagging
-        uses: anothrNick/github-tag-action@4ed44965e0db8dab2b466a16da04aec3cc312fd8 # 1.75.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DEFAULT_BRANCH: master
-          INITIAL_VERSION: 1.0.0
-          BRANCH_HISTORY: last
+      - name: Derive tag
+        id: tag
+        shell: bash
+        run: |
+          echo "ref_name=${GITHUB_REF_NAME}" >> $GITHUB_OUTPUT
+          echo "tag=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
       - name: Set up QEMU
-        if: steps.tagging.outputs.part != '' && steps.tagging.outputs.part != 'none'
+        if: startsWith(github.ref, 'refs/tags/')
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
 
       - name: Set up Docker Buildx
-        if: steps.tagging.outputs.part != '' && steps.tagging.outputs.part != 'none'
+        if: startsWith(github.ref, 'refs/tags/')
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Login to ghcr.io
-        if: steps.tagging.outputs.part != '' && steps.tagging.outputs.part != 'none'
+        if: startsWith(github.ref, 'refs/tags/')
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
         with:
           registry: ghcr.io
@@ -48,7 +43,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        if: steps.tagging.outputs.part != '' && steps.tagging.outputs.part != 'none'
+        if: startsWith(github.ref, 'refs/tags/')
         id: docker_build
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
@@ -57,14 +52,14 @@ jobs:
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           tags: |
             docker.io/naishy/k8s-sidecar:latest
-            docker.io/naishy/k8s-sidecar:${{ steps.tagging.outputs.new_tag }}
+            docker.io/naishy/k8s-sidecar:${{ steps.tag.outputs.tag }}
             quay.io/naishy/k8s-sidecar:latest
-            quay.io/naishy/k8s-sidecar:${{ steps.tagging.outputs.new_tag }}
+            quay.io/naishy/k8s-sidecar:${{ steps.tag.outputs.tag }}
             ghcr.io/naishy/k8s-sidecar:latest
-            ghcr.io/naishy/k8s-sidecar:${{ steps.tagging.outputs.new_tag }}
+            ghcr.io/naishy/k8s-sidecar:${{ steps.tag.outputs.tag }}
 
       - name: Build Changelog
-        if: steps.tagging.outputs.part != '' && steps.tagging.outputs.part != 'none'
+        if: startsWith(github.ref, 'refs/tags/')
         id: build_changelog
         uses: mikepenz/release-changelog-builder-action@439f79b5b5428107c7688c1d2b0e8bacc9b8792c # v6.0.1
         with:
@@ -73,13 +68,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create GitHub Release
-        if: steps.tagging.outputs.part != '' && steps.tagging.outputs.part != 'none'
+        if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b #v2.5.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ steps.tagging.outputs.new_tag }}
-          name: v${{ steps.tagging.outputs.new_tag }}
+          tag_name: ${{ steps.tag.outputs.ref_name }}
+          name: ${{ steps.tag.outputs.ref_name }}
           body: ${{ steps.build_changelog.outputs.changelog }}
           draft: false
           prerelease: false

--- a/.github/workflows/release_test.yaml
+++ b/.github/workflows/release_test.yaml
@@ -71,9 +71,9 @@ jobs:
           provenance: true
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           tags: |
-            docker.io/kiwigrid/k8s-sidecar:${{ steps.tagging.outputs.tag }}-${{ env.TEST_TAG }}
-            quay.io/kiwigrid/k8s-sidecar:${{ steps.tagging.outputs.tag }}-${{ env.TEST_TAG }}
-            ghcr.io/kiwigrid/k8s-sidecar:${{ steps.tagging.outputs.tag }}-${{ env.TEST_TAG }}
+            docker.io/naishy/k8s-sidecar:${{ steps.tagging.outputs.tag }}-${{ env.TEST_TAG }}
+            quay.io/naishy/k8s-sidecar:${{ steps.tagging.outputs.tag }}-${{ env.TEST_TAG }}
+            ghcr.io/naishy/k8s-sidecar:${{ steps.tagging.outputs.tag }}-${{ env.TEST_TAG }}
 
       - name: Build Changelog
         if: steps.tagging.outputs.part

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apk add --no-cache gcc && \
 
 
 FROM base
-LABEL org.opencontainers.image.source=https://github.com/kiwigrid/k8s-sidecar
+LABEL org.opencontainers.image.source=https://github.com/naishy/k8s-sidecar
 LABEL org.opencontainers.image.description="K8s sidecar image to collect configmaps and secrets as files"
 LABEL org.opencontainers.image.licenses=MIT
 ENV         PYTHONUNBUFFERED=1

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 
-[![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/kiwigrid/k8s-sidecar?style=flat)](https://github.com/kiwigrid/k8s-sidecar/releases)
-[![Release](https://github.com/kiwigrid/k8s-sidecar/actions/workflows/release.yaml/badge.svg)](https://github.com/kiwigrid/k8s-sidecar/actions/workflows/release.yaml)
-[![Docker Pulls](https://img.shields.io/docker/pulls/kiwigrid/k8s-sidecar.svg?style=flat)](https://hub.docker.com/r/kiwigrid/k8s-sidecar/)
-![Docker Image Size (latest semver)](https://img.shields.io/docker/image-size/kiwigrid/k8s-sidecar)
+[![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/naishy/k8s-sidecar?style=flat)](https://github.com/naishy/k8s-sidecar/releases)
+[![Release](https://github.com/naishy/k8s-sidecar/actions/workflows/release.yaml/badge.svg)](https://github.com/naishy/k8s-sidecar/actions/workflows/release.yaml)
+[![Docker Pulls](https://img.shields.io/docker/pulls/naishy/k8s-sidecar.svg?style=flat)](https://hub.docker.com/r/naishy/k8s-sidecar/)
+![Docker Image Size (latest semver)](https://img.shields.io/docker/image-size/naishy/k8s-sidecar)
 
 # What?
 
@@ -21,9 +21,9 @@ By adding additional env variables the container can send an HTTP request to spe
 
 Images are available at:
 
-- [docker.io/kiwigrid/k8s-sidecar](https://hub.docker.com/r/kiwigrid/k8s-sidecar)
-- [quay.io/kiwigrid/k8s-sidecar](https://quay.io/repository/kiwigrid/k8s-sidecar)
-- [ghcr.io/kiwigrid/k8s-sidecar](https://github.com/orgs/kiwigrid/packages/container/package/k8s-sidecar)
+- [docker.io/naishy/k8s-sidecar](https://hub.docker.com/r/naishy/k8s-sidecar)
+- [quay.io/naishy/k8s-sidecar](https://quay.io/repository/naishy/k8s-sidecar)
+- [ghcr.io/naishy/k8s-sidecar](https://github.com/orgs/naishy/packages/container/package/k8s-sidecar)
 
 All are identical multi-arch images built for `amd64`, `arm64` and `arm/v7`.
 
@@ -43,7 +43,7 @@ A possible solution would be to setup a dedicated build job using a native runne
 - Support `binaryData` for both `Secret` and `ConfigMap` kinds
   - Binary data content is base64 decoded before generating the file on disk
   - Values can also be base64 encoded URLs that download binary data e.g. executables
-    - The key in the `ConfigMap`/`Secret` must end with "`.url`" ([see](https://github.com/kiwigrid/k8s-sidecar/blob/master/test/resources/resources.yaml#L84))
+    - The key in the `ConfigMap`/`Secret` must end with "`.url`" ([see](https://github.com/naishy/k8s-sidecar/blob/master/test/resources/resources.yaml#L84))
 
 # Usage
 
@@ -104,8 +104,8 @@ If the filename ends with `.url` suffix, the content will be processed as a URL 
 | `DEFAULT_FILE_MODE`        | The default file system permission for every file. Use three digits (e.g. '500', '440', ...)                                                                                                                                                                                                                                        | false    | -                                         | string  |
 | `KUBECONFIG`               | if this is given and points to a file or `~/.kube/config` is mounted k8s config will be loaded from this file, otherwise "incluster" k8s configuration is tried.                                                                                                                                                                    | false    | -                                         | string  |
 | `ENABLE_5XX`               | Set to `true` to enable pulling of 5XX response content from config map. Used in case if the filename ends with `.url` suffix (Please refer to the `*.url` feature here.)                                                                                                                                                           | false    | -                                         | boolean |
-| `WATCH_SERVER_TIMEOUT`     | polite request to the server, asking it to cleanly close watch connections after this amount of seconds ([#85](https://github.com/kiwigrid/k8s-sidecar/issues/85))                                                                                                                                                                  | false    | `60`                                      | integer |
-| `WATCH_CLIENT_TIMEOUT`     | If you have a network outage dropping all packets with no RST/FIN, this is how many seconds your client waits on watches before realizing & dropping the connection. You can keep this number low. ([#85](https://github.com/kiwigrid/k8s-sidecar/issues/85))                                                                       | false    | `66`                                      | integer |
+| `WATCH_SERVER_TIMEOUT`     | polite request to the server, asking it to cleanly close watch connections after this amount of seconds ([#85](https://github.com/naishy/k8s-sidecar/issues/85))                                                                                                                                                                  | false    | `60`                                      | integer |
+| `WATCH_CLIENT_TIMEOUT`     | If you have a network outage dropping all packets with no RST/FIN, this is how many seconds your client waits on watches before realizing & dropping the connection. You can keep this number low. ([#85](https://github.com/naishy/k8s-sidecar/issues/85))                                                                       | false    | `66`                                      | integer |
 | `IGNORE_ALREADY_PROCESSED` | Ignore already processed resource version. Avoid numerous checks on same unchanged resource. req kubernetes api >= v1.19                                                                                                                                                                                                            | false    | `false`                                   | boolean |
 | `LOG_LEVEL`                | Set the logging level. (DEBUG, INFO, WARN, ERROR, CRITICAL)                                                                                                                                                                                                                                                                         | false    | `INFO`                                    | string  |
 | `LOG_FORMAT`               | Set a log format. (JSON or LOGFMT)                                                                                                                                                                                                                                                                                                  | false    | `JSON`                                    | string  |
@@ -195,9 +195,9 @@ This workflow does **not** create tags, releases, or push images to registries.
 - **What it does when a new tag is created:**
   - Builds multi-arch images for the sidecar.
   - Pushes images to:
-    - `docker.io/kiwigrid/k8s-sidecar`
-    - `quay.io/kiwigrid/k8s-sidecar`
-    - `ghcr.io/kiwigrid/k8s-sidecar`
+    - `docker.io/naishy/k8s-sidecar`
+    - `quay.io/naishy/k8s-sidecar`
+    - `ghcr.io/naishy/k8s-sidecar`
   - Tags: `<new_tag>` and `latest`.
   - Builds a changelog.
   - Creates a GitHub release for the new tag.

--- a/example.yaml
+++ b/example.yaml
@@ -1,0 +1,364 @@
+
+name: 'Scan Container Image'
+description: 'Performs security scanning with Dockle and Trivy in parallel'
+author: 'LECN Team'
+
+inputs:
+  image_reference:
+    description: 'Full image reference to scan'
+    required: true
+  upload_sarif:
+    description: 'Whether to upload SARIF results to GitHub Security'
+    required: false
+    default: 'true'
+  acr_name:
+    description: 'Azure Container Registry name for authentication'
+    required: false
+    default: ''
+  dockle_ignore:
+    description: 'Comma-separated list of Dockle checkpoints to ignore (e.g., CIS-DI-0001,DKL-DI-0006)'
+    required: false
+    default: ''
+  trivy_ignore:
+    description: 'Comma-separated list of vulnerability IDs for Trivy to ignore (e.g., CVE-2021-44228,CVE-2022-12345)'
+    required: false
+    default: ''
+  bypass_failures:
+    description: 'Allow scan failures without failing the build (WARNING: for special cases only)'
+    required: false
+    default: 'false'
+
+outputs:
+  dockle_result:
+    description: 'Dockle scan result (success/failure)'
+    value: ${{ steps.results.outputs.dockle_result }}
+  trivy_result:
+    description: 'Trivy scan result (success/failure)'
+    value: ${{ steps.results.outputs.trivy_result }}
+  trivy_critical:
+    description: 'Number of CRITICAL vulnerabilities found'
+    value: ${{ steps.parse-results.outputs.trivy_critical }}
+  trivy_high:
+    description: 'Number of HIGH vulnerabilities found'
+    value: ${{ steps.parse-results.outputs.trivy_high }}
+  trivy_medium:
+    description: 'Number of MEDIUM vulnerabilities found'
+    value: ${{ steps.parse-results.outputs.trivy_medium }}
+  trivy_low:
+    description: 'Number of LOW vulnerabilities found'
+    value: ${{ steps.parse-results.outputs.trivy_low }}
+  trivy_severity:
+    description: 'Configured Trivy severity levels'
+    value: ${{ steps.config.outputs.trivy_severity }}
+  dockle_fatal:
+    description: 'Number of FATAL Dockle issues found'
+    value: ${{ steps.parse-results.outputs.dockle_fatal }}
+  dockle_warn:
+    description: 'Number of WARNING Dockle issues found'
+    value: ${{ steps.parse-results.outputs.dockle_warn }}
+  bypassed:
+    description: 'Whether scan failures were bypassed'
+    value: ${{ steps.results.outputs.bypassed }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Read security config
+      id: config
+      shell: bash
+      run: |
+        CONFIG_FILE="security-config.yaml"
+        
+        # Install yq if needed
+        if ! command -v yq &>/dev/null; then
+          wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          chmod +x /usr/local/bin/yq
+        fi
+        
+        # Read config with defaults
+        if [[ -f "$CONFIG_FILE" ]]; then
+          TRIVY_SEVERITY=$(yq '.trivy.fail_on_severity // "CRITICAL,HIGH"' "$CONFIG_FILE")
+          TRIVY_TIMEOUT=$(yq '.trivy.timeout // "10m"' "$CONFIG_FILE")
+          DOCKLE_EXIT_LEVEL=$(yq '.dockle.exit_level // "warn"' "$CONFIG_FILE")
+        else
+          echo "⚠️ security-config.yaml not found, using defaults"
+          TRIVY_SEVERITY="CRITICAL,HIGH"
+          TRIVY_TIMEOUT="10m"
+          DOCKLE_EXIT_LEVEL="warn"
+        fi
+        
+        echo "trivy_severity=$TRIVY_SEVERITY" >> $GITHUB_OUTPUT
+        echo "trivy_timeout=$TRIVY_TIMEOUT" >> $GITHUB_OUTPUT
+        echo "dockle_exit_level=$DOCKLE_EXIT_LEVEL" >> $GITHUB_OUTPUT
+        
+        echo "📋 Security thresholds:"
+        echo "   Trivy severity: $TRIVY_SEVERITY"
+        echo "   Trivy timeout: $TRIVY_TIMEOUT"
+        echo "   Dockle exit level: $DOCKLE_EXIT_LEVEL"
+
+    - name: Login and pull image from ACR for scanning
+      if: inputs.acr_name != ''
+      shell: bash
+      run: |
+        az acr login --name ${{ inputs.acr_name }}
+        docker pull ${{ inputs.image_reference }}
+
+    - name: Create Trivy ignore file
+      if: inputs.trivy_ignore != ''
+      shell: bash
+      run: |
+        echo "Creating .trivyignore file with vulnerabilities to ignore"
+        echo "${{ inputs.trivy_ignore }}" | tr ',' '\n' > .trivyignore
+        echo "Contents of .trivyignore:"
+        cat .trivyignore
+
+    - name: Setup Dockle
+      shell: bash
+      run: ./scripts/install-dockle.sh
+
+    - name: Setup Trivy
+      uses: aquasecurity/setup-trivy@e6c2c5e321ed9123bda567646e2f96565e34abe1 # v0.2.0
+      with:
+        version: 'latest'
+
+    - name: Get current date
+      id: date
+      shell: bash
+      run: echo "date=$(date +%Y-%m-%d)" >> $GITHUB_OUTPUT
+
+    - name: Cache Trivy DB
+      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.1.2
+      with:
+        path: ~/.cache/trivy
+        key: trivy-db-${{ runner.os }}-${{ steps.date.outputs.date }}
+        restore-keys: |
+          trivy-db-${{ runner.os }}-
+
+    # Run Dockle and Trivy in parallel using background processes
+    - name: Run parallel security scans (Dockle + Trivy)
+      id: parallel-scan
+      shell: bash
+      run: |
+        echo "🔍 Starting parallel security scans..."
+        echo "Image: ${{ inputs.image_reference }}"
+        echo ""
+
+        # Create temp files for results
+        DOCKLE_LOG=$(mktemp)
+        TRIVY_LOG=$(mktemp)
+        DOCKLE_EXIT=$(mktemp)
+        TRIVY_EXIT=$(mktemp)
+
+        # Read config values
+        TRIVY_SEVERITY="${{ steps.config.outputs.trivy_severity }}"
+        TRIVY_TIMEOUT="${{ steps.config.outputs.trivy_timeout }}"
+        DOCKLE_EXIT_LEVEL="${{ steps.config.outputs.dockle_exit_level }}"
+
+        # Run Dockle in background (with JSON output for parsing)
+        echo "Starting Dockle scan..."
+        (
+          set +e  # Don't exit on error - we need to capture the exit code
+          
+          # Build ignore flags
+          IGNORE_FLAGS=""
+          if [ -n "${{ inputs.dockle_ignore }}" ]; then
+            for check in $(echo "${{ inputs.dockle_ignore }}" | tr ',' ' '); do
+              IGNORE_FLAGS="$IGNORE_FLAGS --ignore $check"
+            done
+          fi
+          
+          # Run with JSON output for later parsing (stdout only, stderr to log)
+          dockle --exit-code 1 --exit-level "$DOCKLE_EXIT_LEVEL" -f json $IGNORE_FLAGS \
+            "${{ inputs.image_reference }}" > dockle-results.json 2>"$DOCKLE_LOG"
+          DOCKLE_CODE=$?
+          
+          # Also capture text format for better log readability
+          dockle --exit-code 1 --exit-level "$DOCKLE_EXIT_LEVEL" $IGNORE_FLAGS \
+            "${{ inputs.image_reference }}" >> "$DOCKLE_LOG" 2>&1 || true
+          
+          echo $DOCKLE_CODE > "$DOCKLE_EXIT"
+        ) &
+        DOCKLE_PID=$!
+
+        # Run Trivy in background
+        echo "Starting Trivy scan..."
+        (
+          set +e  # Don't exit on error - we need to capture the exit code
+          
+          TRIVY_OPTS="--exit-code 1 --severity $TRIVY_SEVERITY --timeout $TRIVY_TIMEOUT"
+          [[ -f ".trivyignore" ]] && TRIVY_OPTS="$TRIVY_OPTS --ignorefile .trivyignore"
+          
+          trivy image "${{ inputs.image_reference }}" -f json -o trivy-results.json $TRIVY_OPTS > "$TRIVY_LOG" 2>&1
+          echo $? > "$TRIVY_EXIT"
+        ) &
+        TRIVY_PID=$!
+
+        echo "⏳ Waiting for scans to complete..."
+        echo "  Dockle PID: $DOCKLE_PID"
+        echo "  Trivy PID: $TRIVY_PID"
+
+        # Wait for both to complete (ignore exit codes from wait - we capture them from temp files)
+        wait $DOCKLE_PID || true
+        wait $TRIVY_PID || true
+
+        # Read exit codes from temp files (written by the subshells)
+        DOCKLE_RC=$(cat "$DOCKLE_EXIT" 2>/dev/null || echo "1")
+        TRIVY_RC=$(cat "$TRIVY_EXIT" 2>/dev/null || echo "1")
+
+        echo ""
+        echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+        echo "📋 DOCKLE RESULTS (exit code: $DOCKLE_RC)"
+        echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+        cat "$DOCKLE_LOG"
+        echo ""
+
+        echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+        echo "📋 TRIVY RESULTS (exit code: $TRIVY_RC)"
+        echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+        cat "$TRIVY_LOG"
+        echo ""
+
+        # Store results for later steps
+        echo "dockle_exit_code=$DOCKLE_RC" >> $GITHUB_OUTPUT
+        echo "trivy_exit_code=$TRIVY_RC" >> $GITHUB_OUTPUT
+
+        # Clean up temp files
+        rm -f "$DOCKLE_LOG" "$TRIVY_LOG" "$DOCKLE_EXIT" "$TRIVY_EXIT"
+      env:
+        DOCKLE_IGNORE: ${{ inputs.dockle_ignore }}
+
+    - name: Parse vulnerability counts
+      id: parse-results
+      if: always()  # Must run to output counts even if scans found issues
+      shell: bash
+      run: |
+        echo "Parsing scan results for vulnerability counts..."
+        
+        # Parse Trivy results - count all severity levels
+        if [ -f "trivy-results.json" ]; then
+          CRITICAL_COUNT=$(jq '[.Results[]?.Vulnerabilities[]? | select(.Severity == "CRITICAL")] | length' trivy-results.json 2>/dev/null || echo "0")
+          HIGH_COUNT=$(jq '[.Results[]?.Vulnerabilities[]? | select(.Severity == "HIGH")] | length' trivy-results.json 2>/dev/null || echo "0")
+          MEDIUM_COUNT=$(jq '[.Results[]?.Vulnerabilities[]? | select(.Severity == "MEDIUM")] | length' trivy-results.json 2>/dev/null || echo "0")
+          LOW_COUNT=$(jq '[.Results[]?.Vulnerabilities[]? | select(.Severity == "LOW")] | length' trivy-results.json 2>/dev/null || echo "0")
+          echo "trivy_critical=$CRITICAL_COUNT" >> $GITHUB_OUTPUT
+          echo "trivy_high=$HIGH_COUNT" >> $GITHUB_OUTPUT
+          echo "trivy_medium=$MEDIUM_COUNT" >> $GITHUB_OUTPUT
+          echo "trivy_low=$LOW_COUNT" >> $GITHUB_OUTPUT
+          echo "Trivy: $CRITICAL_COUNT critical, $HIGH_COUNT high, $MEDIUM_COUNT medium, $LOW_COUNT low"
+        else
+          echo "trivy_critical=0" >> $GITHUB_OUTPUT
+          echo "trivy_high=0" >> $GITHUB_OUTPUT
+          echo "trivy_medium=0" >> $GITHUB_OUTPUT
+          echo "trivy_low=0" >> $GITHUB_OUTPUT
+        fi
+        
+        # Parse Dockle results from JSON
+        if [ -f "dockle-results.json" ]; then
+          FATAL_COUNT=$(jq '[.details[]? | select(.level == "FATAL")] | length' dockle-results.json 2>/dev/null || echo "0")
+          WARN_COUNT=$(jq '[.details[]? | select(.level == "WARN")] | length' dockle-results.json 2>/dev/null || echo "0")
+          echo "dockle_fatal=$FATAL_COUNT" >> $GITHUB_OUTPUT
+          echo "dockle_warn=$WARN_COUNT" >> $GITHUB_OUTPUT
+          echo "Dockle: $FATAL_COUNT fatal, $WARN_COUNT warnings"
+        else
+          echo "dockle_fatal=0" >> $GITHUB_OUTPUT
+          echo "dockle_warn=0" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Convert Trivy results
+      shell: bash
+      run: |
+        TRIVY_SEVERITY="${{ steps.config.outputs.trivy_severity }}"
+        
+        if [ -f "trivy-results.json" ]; then
+          echo "Converting Trivy JSON results to table and SARIF formats"
+          echo "Original JSON file size: $(ls -lh trivy-results.json)"
+
+          echo "=== Trivy Results (Table Format) ==="
+          trivy convert -f table --severity "$TRIVY_SEVERITY" trivy-results.json || true
+
+          echo "=== Converting to SARIF ==="
+          trivy convert -f sarif --severity "$TRIVY_SEVERITY" -o trivy-results.sarif trivy-results.json || true
+
+          if [ -f "trivy-results.sarif" ]; then
+            echo "SARIF file created: $(ls -lh trivy-results.sarif)"
+          else
+            echo "Warning: SARIF file was not created"
+            echo '{"version":"2.1.0","$schema":"https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json","runs":[{"tool":{"driver":{"name":"Trivy"}},"results":[]}]}'> trivy-results.sarif
+          fi
+        else
+          echo "Warning: trivy-results.json not found"
+        fi
+
+    - name: Upload Trivy scan results to GitHub Security tab
+      uses: github/codeql-action/upload-sarif@755f44910c12a3d7ca0d8c6e42c048b3362f7cec # v3.30.8
+      if: always() && hashFiles('trivy-results.sarif') != ''
+      continue-on-error: true
+      with:
+        sarif_file: 'trivy-results.sarif'
+
+    - name: Evaluate scan results
+      id: results
+      if: always()  # Must run to output results even if previous steps had issues
+      shell: bash
+      run: |
+        DOCKLE_RC="${{ steps.parallel-scan.outputs.dockle_exit_code }}"
+        TRIVY_RC="${{ steps.parallel-scan.outputs.trivy_exit_code }}"
+        BYPASS_FAILURES="${{ inputs.bypass_failures }}"
+        
+        # Default to failure (1) if exit codes are empty (scans didn't run)
+        [ -z "$DOCKLE_RC" ] && DOCKLE_RC="1"
+        [ -z "$TRIVY_RC" ] && TRIVY_RC="1"
+        
+        echo ""
+        echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+        echo "📊 SECURITY SCAN SUMMARY"
+        echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+        
+        FAILED=false
+        
+        if [ "$DOCKLE_RC" -eq 0 ] 2>/dev/null; then
+          echo "✅ Dockle: PASSED"
+          echo "dockle_result=success" >> $GITHUB_OUTPUT
+        else
+          echo "❌ Dockle: FAILED (exit code $DOCKLE_RC)"
+          echo "dockle_result=failure" >> $GITHUB_OUTPUT
+          FAILED=true
+        fi
+        
+        if [ "$TRIVY_RC" -eq 0 ] 2>/dev/null; then
+          echo "✅ Trivy: PASSED"
+          echo "trivy_result=success" >> $GITHUB_OUTPUT
+        else
+          echo "❌ Trivy: FAILED (exit code $TRIVY_RC)"
+          echo "trivy_result=failure" >> $GITHUB_OUTPUT
+          FAILED=true
+        fi
+        
+        echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+        
+        if [ "$FAILED" = true ]; then
+          echo ""
+          if [ "$BYPASS_FAILURES" = "true" ]; then
+            echo "⚠️  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+            echo "⚠️  WARNING: SECURITY SCAN FAILURES BYPASSED"
+            echo "⚠️  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+            echo "⚠️  One or more security scans failed, but bypass_security_scans"
+            echo "⚠️  is enabled. This image will be promoted DESPITE the failures."
+            echo "⚠️  "
+            echo "⚠️  THIS IS A SECURITY RISK. Only use for:"
+            echo "⚠️  - Penetration testing images"
+            echo "⚠️  - Temporary workarounds with documented exceptions"
+            echo "⚠️  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+            echo ""
+            echo "bypassed=true" >> $GITHUB_OUTPUT
+          else
+            echo "⚠️  One or more security scans failed!"
+            echo "Review the results above and consider:"
+            echo "  - Updating dockle_ignore/trivy_ignore in dockerimages.yaml"
+            echo "  - Setting bypass_security_scans: true (for special cases only)"
+            exit 1
+          fi
+        else
+          echo ""
+          echo "🎉 All security scans passed!"
+        fi

--- a/examples/example.yaml
+++ b/examples/example.yaml
@@ -24,7 +24,7 @@ spec:
         command: ["watch"]
         args: ["ls", "/tmp/"]
       - name: sidecar
-        image: kiwigrid/k8s-sidecar:latest
+        image: naishy/k8s-sidecar:latest
         volumeMounts:
         - name: shared-volume
           mountPath: /tmp/

--- a/pr-image-scan.yaml
+++ b/pr-image-scan.yaml
@@ -1,0 +1,505 @@
+# PR Image Scanner Workflow
+# Detects changes to images in dockerimages.yaml and runs parallel security scans
+# Uses shared actions to avoid duplicating logic across workflows
+
+name: PR Image Scanner
+
+on:
+  pull_request:
+    paths:
+      - 'dockerimages.yaml'
+    branches:
+      - main
+
+jobs:
+  detect-changes:
+    name: Detect changed images
+    runs-on: ubuntu-latest
+    outputs:
+      changed_images: ${{ steps.detect.outputs.changed_images }}
+      has_changes: ${{ steps.detect.outputs.has_changes }}
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+
+      - name: Checkout base branch for comparison
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        with:
+          ref: ${{ github.base_ref }}
+          path: base
+
+      - name: Detect changed image blocks
+        id: detect
+        run: ./scripts/detect-changed-images.sh base/dockerimages.yaml
+
+  scan-images:
+    name: Scan ${{ matrix.image.name }}
+    needs: [detect-changes]
+    if: needs.detect-changes.outputs.has_changes == 'true'
+    runs-on: vnet-integrated
+    strategy:
+      fail-fast: false
+      matrix:
+        image: ${{ fromJson(needs.detect-changes.outputs.changed_images) }}
+    permissions:
+      id-token: write
+      actions: read
+      contents: read
+      packages: read
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+
+      - name: Login to Azure
+        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Get Key Vault Secrets (for Nominet images)
+        id: get-secrets
+        if: contains(matrix.image.source, 'nominet.jfrog.io')
+        shell: bash
+        run: ./scripts/get-keyvault-secrets.sh "${{ vars.KEY_VAULT_NAME }}" artifactory-password
+
+      # Use shared action for pulling and authenticating
+      - name: Pull and verify source image
+        uses: ./.github/actions/pull-source-image
+        with:
+          source: ${{ matrix.image.source }}
+          version: ${{ matrix.image.version }}
+          digest: ${{ matrix.image.digest }}
+          artifactory_password: ${{ steps.get-secrets.outputs.ARTIFACTORY_PASSWORD }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_actor: ${{ github.actor }}
+
+      # Use shared scan-image action (DRY principle)
+      # Note: This step will fail if vulnerabilities are detected (unless bypass is enabled)
+      # Subsequent steps use if: always() to ensure results are still collected
+      - name: Run security scans
+        id: scan
+        uses: ./.github/actions/scan-image
+        with:
+          image_reference: ${{ matrix.image.source }}:${{ matrix.image.version }}
+          dockle_ignore: ${{ matrix.image.dockle_ignore }}
+          trivy_ignore: ${{ matrix.image.trivy_ignore }}
+          bypass_failures: ${{ matrix.image.bypass_scans }}
+          upload_sarif: 'false'
+
+      # Create scan summary JSON for the PR comment job (runs even if scan failed)
+      - name: Create scan summary
+        id: summary
+        if: always()
+        shell: bash
+        run: |
+          echo "Creating scan summary for ${{ matrix.image.name }}"
+
+          # Get values from scan outputs, with defaults
+          DOCKLE_RESULT="${{ steps.scan.outputs.dockle_result }}"
+          TRIVY_RESULT="${{ steps.scan.outputs.trivy_result }}"
+          : "${DOCKLE_RESULT:=failure}"
+          : "${TRIVY_RESULT:=failure}"
+
+          TRIVY_CRITICAL="${{ steps.scan.outputs.trivy_critical }}"
+          TRIVY_HIGH="${{ steps.scan.outputs.trivy_high }}"
+          TRIVY_MEDIUM="${{ steps.scan.outputs.trivy_medium }}"
+          TRIVY_LOW="${{ steps.scan.outputs.trivy_low }}"
+          TRIVY_SEVERITY="${{ steps.scan.outputs.trivy_severity }}"
+          DOCKLE_FATAL="${{ steps.scan.outputs.dockle_fatal }}"
+          DOCKLE_WARN="${{ steps.scan.outputs.dockle_warn }}"
+          : "${TRIVY_CRITICAL:=0}" "${TRIVY_HIGH:=0}" "${TRIVY_MEDIUM:=0}" "${TRIVY_LOW:=0}" "${DOCKLE_FATAL:=0}" "${DOCKLE_WARN:=0}"
+          : "${TRIVY_SEVERITY:=CRITICAL,HIGH}"
+
+          # Determine overall result
+          if [ "$DOCKLE_RESULT" == "success" ] && [ "$TRIVY_RESULT" == "success" ]; then
+            OVERALL_RESULT="passed"
+          elif [ "${{ matrix.image.bypass_scans }}" == "true" ]; then
+            OVERALL_RESULT="bypassed"
+          else
+            OVERALL_RESULT="failed"
+          fi
+
+          # Build jq filter based on configured severity levels
+          # This ensures we extract vulnerabilities matching the configured fail_on_severity
+          SEVERITY_FILTER=""
+          if echo "$TRIVY_SEVERITY" | grep -qi "CRITICAL"; then
+            SEVERITY_FILTER='.Severity == "CRITICAL"'
+          fi
+          if echo "$TRIVY_SEVERITY" | grep -qi "HIGH"; then
+            [ -n "$SEVERITY_FILTER" ] && SEVERITY_FILTER="$SEVERITY_FILTER or "
+            SEVERITY_FILTER="${SEVERITY_FILTER}.Severity == \"HIGH\""
+          fi
+          if echo "$TRIVY_SEVERITY" | grep -qi "MEDIUM"; then
+            [ -n "$SEVERITY_FILTER" ] && SEVERITY_FILTER="$SEVERITY_FILTER or "
+            SEVERITY_FILTER="${SEVERITY_FILTER}.Severity == \"MEDIUM\""
+          fi
+          if echo "$TRIVY_SEVERITY" | grep -qi "LOW"; then
+            [ -n "$SEVERITY_FILTER" ] && SEVERITY_FILTER="$SEVERITY_FILTER or "
+            SEVERITY_FILTER="${SEVERITY_FILTER}.Severity == \"LOW\""
+          fi
+          # Default to CRITICAL,HIGH if nothing matched
+          [ -z "$SEVERITY_FILTER" ] && SEVERITY_FILTER='.Severity == "CRITICAL" or .Severity == "HIGH"'
+
+          echo "Extracting vulnerabilities with filter: $SEVERITY_FILTER"
+
+          # Extract Trivy vulnerabilities matching configured severity
+          TRIVY_VULNS="[]"
+          [ -f "trivy-results.json" ] && TRIVY_VULNS=$(jq --arg filter "$SEVERITY_FILTER" '[.Results[]? | select(.Vulnerabilities) | .Vulnerabilities[] | select('"$SEVERITY_FILTER"') | {id: .VulnerabilityID, severity: .Severity, package: .PkgName, installed_version: .InstalledVersion, fixed_version: (.FixedVersion // "Not fixed"), title: ((.Title // "N/A") | gsub("\n"; " ") | .[0:100])}]' trivy-results.json 2>/dev/null) || TRIVY_VULNS="[]"
+
+          # Extract Dockle issues
+          DOCKLE_ISSUES="[]"
+          [ -f "dockle-results.json" ] && DOCKLE_ISSUES=$(jq '[.details[]? | select(.level == "FATAL" or .level == "WARN") | {code, level, title, alerts: [.alerts[]? | .[0:100]]}]' dockle-results.json 2>/dev/null) || DOCKLE_ISSUES="[]"
+
+          # Create summary JSON (using heredoc for cleaner output)
+          cat > scan-summary.json <<EOF
+          {
+            "name": "${{ matrix.image.name }}",
+            "source": "${{ matrix.image.source }}",
+            "version": "${{ matrix.image.version }}",
+            "dockle_result": "$DOCKLE_RESULT",
+            "trivy_result": "$TRIVY_RESULT",
+            "overall_result": "$OVERALL_RESULT",
+            "bypass_scans": ${{ matrix.image.bypass_scans }},
+            "dockle_ignore": "${{ matrix.image.dockle_ignore }}",
+            "trivy_ignore": "${{ matrix.image.trivy_ignore }}",
+            "trivy_critical": $TRIVY_CRITICAL,
+            "trivy_high": $TRIVY_HIGH,
+            "trivy_medium": $TRIVY_MEDIUM,
+            "trivy_low": $TRIVY_LOW,
+            "trivy_severity": "$TRIVY_SEVERITY",
+            "dockle_fatal": $DOCKLE_FATAL,
+            "dockle_warn": $DOCKLE_WARN,
+            "trivy_vulns": $TRIVY_VULNS,
+            "dockle_issues": $DOCKLE_ISSUES
+          }
+          EOF
+
+          echo "Scan summary:"
+          cat scan-summary.json
+
+      - name: Upload scan results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: scan-results-${{ matrix.image.name }}
+          path: |
+            scan-summary.json
+            trivy-results.json
+            dockle-results.json
+          retention-days: 7
+          if-no-files-found: warn
+
+  # Single job to create PR comment after all scans complete
+  update-pr-comment:
+    name: Update PR Comment
+    needs: [detect-changes, scan-images]
+    if: always() && needs.detect-changes.outputs.has_changes == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      actions: read
+    steps:
+      - name: Download all scan artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: scan-results-*
+          path: scan-results
+          merge-multiple: false
+
+      - name: Collect all scan results
+        id: collect
+        shell: bash
+        run: |
+          echo "Collecting scan results from artifacts..."
+
+          # Combine all scan summaries using jq slurp mode (file-based, avoids ARG_MAX limits)
+          # This handles large scan-summary.json files (e.g., images with many vulnerabilities)
+          SUMMARY_FILES=()
+          for dir in scan-results/*/; do
+            if [ -f "${dir}scan-summary.json" ]; then
+              SUMMARY_FILES+=("${dir}scan-summary.json")
+              echo "Found results: ${dir}scan-summary.json"
+            fi
+          done
+
+          if [ ${#SUMMARY_FILES[@]} -gt 0 ]; then
+            # Use jq -s (slurp) to combine all JSON files into an array
+            jq -s '.' "${SUMMARY_FILES[@]}" > all-results.json
+            echo "Combined ${#SUMMARY_FILES[@]} scan results"
+          else
+            echo "[]" > all-results.json
+            echo "No scan results found"
+          fi
+
+          # Also check for any images that didn't produce artifacts (failed early)
+          CHANGED_IMAGES='${{ needs.detect-changes.outputs.changed_images }}'
+          FOUND_NAMES=$(jq -r '.[].name' all-results.json)
+
+          for img in $(echo "$CHANGED_IMAGES" | jq -r '.[].name'); do
+            if ! echo "$FOUND_NAMES" | grep -q "^${img}$"; then
+              echo "WARNING: No results found for $img - scan may have failed early"
+              # Add a placeholder result using file-based approach
+              SOURCE=$(echo "$CHANGED_IMAGES" | jq -r ".[] | select(.name == \"$img\") | .source")
+              VERSION=$(echo "$CHANGED_IMAGES" | jq -r ".[] | select(.name == \"$img\") | .version")
+              BYPASS=$(echo "$CHANGED_IMAGES" | jq -r ".[] | select(.name == \"$img\") | .bypass_scans")
+
+              # Create placeholder in a temp file to avoid ARG_MAX issues
+              jq -n \
+                --arg name "$img" \
+                --arg source "$SOURCE" \
+                --arg version "$VERSION" \
+                --argjson bypass_scans "${BYPASS:-false}" \
+                '{
+                  name: $name,
+                  source: $source,
+                  version: $version,
+                  dockle_result: "error",
+                  trivy_result: "error",
+                  overall_result: "error",
+                  bypass_scans: $bypass_scans,
+                  dockle_ignore: "",
+                  trivy_ignore: "",
+                  trivy_critical: 0,
+                  trivy_high: 0,
+                  trivy_medium: 0,
+                  trivy_low: 0,
+                  trivy_severity: "CRITICAL,HIGH",
+                  dockle_fatal: 0,
+                  dockle_warn: 0,
+                  trivy_vulns: [],
+                  dockle_issues: []
+                }' > placeholder.json
+
+              # Merge placeholder into results using file-based slurp
+              jq -s '.[0] + [.[1]]' all-results.json placeholder.json > all-results-new.json
+              mv all-results-new.json all-results.json
+              rm -f placeholder.json
+            fi
+          done
+
+          echo "Total results collected: $(jq 'length' all-results.json)"
+
+      - name: Create or update PR comment
+        uses: actions/github-script@v7
+        env:
+          SCAN_JOB_RESULT: ${{ needs.scan-images.result }}
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- airport-scanner-pr-results -->';
+
+            // Load all scan results
+            const allResults = JSON.parse(fs.readFileSync('all-results.json', 'utf8'));
+            const scanJobResult = process.env.SCAN_JOB_RESULT;
+
+            // Helper functions
+            const getStatusIcon = (result) => {
+              if (result === 'success') return '✅';
+              if (result === 'error') return '❓';
+              return '❌';
+            };
+
+            const getOverallStatusText = (result) => {
+              if (result === 'passed') return '✅ Passed';
+              if (result === 'bypassed') return '⚠️ Bypassed';
+              if (result === 'error') return '❓ Error';
+              return '❌ Failed';
+            };
+
+            const getCveLink = (cveId) => {
+              if (cveId.startsWith('CVE-')) {
+                const year = cveId.split('-')[1];
+                return `[${cveId}](https://avd.aquasec.com/nvd/${year}/${cveId.toLowerCase()}/)`;
+              }
+              return cveId;
+            };
+
+            const getDockleCheckLink = (code) => {
+              const anchor = code.toLowerCase();
+              return `[${code}](https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#${anchor})`;
+            };
+
+            // Build summary table
+            let summaryTable = `| Image | Dockle | Trivy | Ignored | Status |
+            |-------|--------|-------|---------|--------|
+            `;
+
+            // Sort results by name for consistent ordering
+            allResults.sort((a, b) => a.name.localeCompare(b.name));
+
+            for (const result of allResults) {
+              const dockleIcon = getStatusIcon(result.dockle_result);
+              const trivyIcon = getStatusIcon(result.trivy_result);
+              const statusText = getOverallStatusText(result.overall_result);
+              const bypassWarning = result.bypass_scans ? ' ⚠️' : '';
+
+              // Build vulnerability counts - include all configured severity levels
+              const dockleCount = (result.dockle_fatal > 0 || result.dockle_warn > 0)
+                ? ` (${result.dockle_fatal}F/${result.dockle_warn}W)` : '';
+
+              // Build Trivy count based on configured severity
+              const trivySeverity = result.trivy_severity || 'CRITICAL,HIGH';
+              const trivyCountParts = [];
+              if (trivySeverity.includes('CRITICAL') && result.trivy_critical > 0) trivyCountParts.push(`${result.trivy_critical}C`);
+              if (trivySeverity.includes('HIGH') && result.trivy_high > 0) trivyCountParts.push(`${result.trivy_high}H`);
+              if (trivySeverity.includes('MEDIUM') && (result.trivy_medium || 0) > 0) trivyCountParts.push(`${result.trivy_medium}M`);
+              if (trivySeverity.includes('LOW') && (result.trivy_low || 0) > 0) trivyCountParts.push(`${result.trivy_low}L`);
+              const trivyCount = trivyCountParts.length > 0 ? ` (${trivyCountParts.join('/')})` : '';
+
+              // Build exclusion counts
+              const dockleIgnoreCount = result.dockle_ignore ? result.dockle_ignore.split(',').filter(x => x.trim()).length : 0;
+              const trivyIgnoreCount = result.trivy_ignore ? result.trivy_ignore.split(',').filter(x => x.trim()).length : 0;
+              const ignoredCol = (dockleIgnoreCount > 0 || trivyIgnoreCount > 0)
+                ? `${dockleIgnoreCount}D / ${trivyIgnoreCount}T` : '-';
+
+              summaryTable += `| \`${result.name}:${result.version}\`${bypassWarning} | ${dockleIcon}${dockleCount} | ${trivyIcon}${trivyCount} | ${ignoredCol} | ${statusText} |\n`;
+            }
+
+            // Check for bypass warnings
+            const bypassImages = allResults.filter(r => r.bypass_scans);
+            let bypassWarning = '';
+            if (bypassImages.length > 0) {
+              bypassWarning = `\n> ⚠️ **WARNING: Security scan bypass enabled**\n> The following images have \`bypass_security_scans: true\` set:\n${bypassImages.map(img => `> - \`${img.name}\``).join('\n')}\n> \n> These images will be promoted to the golden repository **regardless of scan results**.`;
+            }
+
+            // Build detailed sections for each image
+            let detailSections = '';
+
+            for (const result of allResults) {
+              // Skip if no issues found
+              const hasIssues = result.trivy_vulns.length > 0 || result.dockle_issues.length > 0;
+              const hasExclusions = result.dockle_ignore || result.trivy_ignore;
+
+              if (!hasIssues && !hasExclusions && result.overall_result === 'passed') {
+                continue; // Skip clean images
+              }
+
+              detailSections += `\n<details>\n<summary>📋 <strong>${result.name}</strong> - ${result.source}:${result.version}</summary>\n\n`;
+
+              // Exclusions section
+              if (hasExclusions) {
+                detailSections += `#### 🚫 Configured Exclusions\n`;
+                if (result.dockle_ignore) {
+                  const codes = result.dockle_ignore.split(',').map(c => getDockleCheckLink(c.trim())).join(', ');
+                  detailSections += `- **Dockle ignored:** ${codes}\n`;
+                }
+                if (result.trivy_ignore) {
+                  detailSections += `- **Trivy ignored:** \`${result.trivy_ignore}\`\n`;
+                }
+                detailSections += '\n';
+              }
+
+              // Bypass warning
+              if (result.bypass_scans) {
+                detailSections += `> ⚠️ **BYPASS ENABLED**: This image will be promoted regardless of scan failures!\n\n`;
+              }
+
+              // Combined vulnerabilities table
+              if (result.trivy_vulns.length > 0 || result.dockle_issues.length > 0) {
+                detailSections += `#### 🔍 Detected Issues\n\n`;
+                detailSections += `| Tool | ID | Severity | Details | Versions |\n`;
+                detailSections += `|------|-------|----------|---------|----------|\n`;
+
+                // Add Trivy vulnerabilities
+                for (const vuln of result.trivy_vulns) {
+                  const cveLink = getCveLink(vuln.id);
+                  let severity;
+                  switch (vuln.severity) {
+                    case 'CRITICAL': severity = '🔴 CRITICAL'; break;
+                    case 'HIGH': severity = '🟠 HIGH'; break;
+                    case 'MEDIUM': severity = '🟡 MEDIUM'; break;
+                    case 'LOW': severity = '🔵 LOW'; break;
+                    default: severity = `⚪ ${vuln.severity}`;
+                  }
+                  const versions = vuln.fixed_version !== 'Not fixed'
+                    ? `${vuln.installed_version} → ${vuln.fixed_version}`
+                    : `${vuln.installed_version} (no fix)`;
+                  const details = `**${vuln.package}**: ${vuln.title}`;
+                  detailSections += `| Trivy | ${cveLink} | ${severity} | ${details} | ${versions} |\n`;
+                }
+
+                // Add Dockle issues
+                for (const issue of result.dockle_issues) {
+                  const codeLink = getDockleCheckLink(issue.code);
+                  const severity = issue.level === 'FATAL' ? '🔴 FATAL' : '🟡 WARN';
+                  let details = issue.title;
+                  if (issue.alerts && issue.alerts.length > 0) {
+                    details += `: ${issue.alerts.slice(0, 2).join(', ')}`;
+                    if (issue.alerts.length > 2) {
+                      details += ` (+${issue.alerts.length - 2} more)`;
+                    }
+                  }
+                  detailSections += `| Dockle | ${codeLink} | ${severity} | ${details} | - |\n`;
+                }
+              } else if (result.overall_result === 'error') {
+                detailSections += `⚠️ **Scan error**: The scan did not complete successfully. Check the [workflow logs](${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}) for details.\n`;
+              } else {
+                // Format severity levels for display
+                const trivySeverity = result.trivy_severity || 'CRITICAL,HIGH';
+                const severityList = trivySeverity.split(',').map(s => s.trim()).join(' or ');
+                detailSections += `✅ No ${severityList} vulnerabilities detected\n`;
+              }
+
+              detailSections += `\n</details>\n`;
+            }
+
+            // Build final status
+            let finalStatus;
+            if (scanJobResult === 'success') {
+              finalStatus = '✅ **All security scans completed successfully!**';
+            } else if (scanJobResult === 'failure') {
+              finalStatus = '❌ **Some security scans failed.** Please review the details above and consider:\n- Adding exclusions to `dockle_ignore` or `trivy_ignore`\n- Setting `bypass_security_scans: true` for special cases';
+            } else {
+              finalStatus = `⚠️ **Scan workflow completed with status: ${scanJobResult}**`;
+            }
+
+            // Compose the full comment
+            const body = `${marker}
+            ### 🔍 Security Scan Results
+
+            ${summaryTable}
+            ${bypassWarning}
+            ${detailSections}
+            ---
+            ${finalStatus}
+
+            [View Workflow Run](${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID})`;
+
+            // Find existing comment or create new one
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const existing = comments.find(c => c.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: body
+              });
+              console.log('Updated existing PR comment');
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: body
+              });
+              console.log('Created new PR comment');
+            }
+
+      - name: Check overall status
+        shell: bash
+        run: |
+          if [ "${{ needs.scan-images.result }}" == "failure" ]; then
+            echo "❌ One or more image scans failed"
+            exit 1
+          else
+            echo "✅ All image scans passed (or were bypassed)"
+          fi

--- a/src/helpers.py
+++ b/src/helpers.py
@@ -16,7 +16,7 @@ from types import SimpleNamespace
 from logger import get_logger
 import argparse
 
-parser = argparse.ArgumentParser(description="CLI flags for kiwigrid sidecar")
+parser = argparse.ArgumentParser(description="CLI flags for naishy sidecar")
 parser.add_argument("--req-username-file", type=str, metavar=argparse.REMAINDER, help="path to file containing basic-auth username for REQ. This takes precedence over the environment variable REQ_USERNAME")
 parser.add_argument("--req-password-file", type=str, metavar=argparse.REMAINDER, help="path to file containing basic-auth password for REQ. This takes precedence over the environment variable REQ_PASSWORD")
 args = parser.parse_args()

--- a/test/resources/sidecar.yaml
+++ b/test/resources/sidecar.yaml
@@ -49,7 +49,7 @@ spec:
   serviceAccountName: sample-acc
   containers:
   - name: sidecar
-    image: kiwigrid/k8s-sidecar:testing
+    image: naishy/k8s-sidecar:testing
     volumeMounts:
     - name: shared-volume
       mountPath: /tmp/
@@ -91,7 +91,7 @@ spec:
   serviceAccountName: sample-acc
   containers:
   - name: sidecar
-    image: kiwigrid/k8s-sidecar:testing
+    image: naishy/k8s-sidecar:testing
     volumeMounts:
     - name: shared-volume
       mountPath: /tmp/
@@ -147,7 +147,7 @@ spec:
   serviceAccountName: sample-acc
   containers:
     - name: sidecar
-      image: kiwigrid/k8s-sidecar:testing
+      image: naishy/k8s-sidecar:testing
       volumeMounts:
         - name: shared-volume
           mountPath: /tmp/
@@ -182,7 +182,7 @@ spec:
   serviceAccountName: sample-acc
   containers:
   - name: sidecar
-    image: kiwigrid/k8s-sidecar:testing
+    image: naishy/k8s-sidecar:testing
     volumeMounts:
     - name: shared-volume
       mountPath: /tmp-5xx/
@@ -281,7 +281,7 @@ spec:
   serviceAccountName: sample-acc
   containers:
     - name: sidecar
-      image: kiwigrid/k8s-sidecar:testing
+      image: naishy/k8s-sidecar:testing
       volumeMounts:
         - name: shared-volume
           mountPath: /tmp/
@@ -324,7 +324,7 @@ spec:
   serviceAccountName: sample-acc
   containers:
     - name: sidecar
-      image: kiwigrid/k8s-sidecar:testing
+      image: naishy/k8s-sidecar:testing
       volumeMounts:
         - name: shared-volume
           mountPath: /tmp/
@@ -361,7 +361,7 @@ spec:
   serviceAccountName: sample-acc
   containers:
     - name: sidecar
-      image: kiwigrid/k8s-sidecar:testing
+      image: naishy/k8s-sidecar:testing
       volumeMounts:
         - name: shared-volume
           mountPath: /tmp/
@@ -435,7 +435,7 @@ spec:
   serviceAccountName: sample-acc
   containers:
   - name: sidecar
-    image: kiwigrid/k8s-sidecar:testing
+    image: naishy/k8s-sidecar:testing
     command: [ "python" , "-u" , "sidecar.py" , "--req-username-file=/opt/creds/username" , "--req-password-file=/opt/creds/password"]
     imagePullPolicy: IfNotPresent
     volumeMounts:
@@ -489,7 +489,7 @@ spec:
   serviceAccountName: sample-acc
   containers:
   - name: sidecar
-    image: kiwigrid/k8s-sidecar:testing
+    image: naishy/k8s-sidecar:testing
     volumeMounts:
     - name: shared-volume
       mountPath: /tmp/


### PR DESCRIPTION
- Introduced a new workflow `pr-image-scan.yaml` to detect changes in `dockerimages.yaml` and run security scans.
- Created a composite action `example.yaml` for scanning container images using Dockle and Trivy in parallel.
- Updated existing examples to use the new sidecar image `naishy/k8s-sidecar:latest`.
- Modified `helpers.py` to reflect the new sidecar description.
- Updated test resources to use the new sidecar image.