### PR TITLE
fix: TypeError when insufficient privileges to create folder

### DIFF
--- a/src/helpers.py
+++ b/src/helpers.py
@@ -72,7 +72,7 @@ def write_data_to_file(folder, filename, data, data_type=CONTENT_TYPE_TEXT):
             if e.errno == errno.EACCES:
                 logger.error(f"Error: insufficient privileges to create {folder}. "
                              f"Skipping {filename}.")
-                return
+                return False
 
     absolute_path = os.path.join(folder, filename)
     if os.path.exists(absolute_path):


### PR DESCRIPTION
This change fixes the following error:
```
Error: insufficient privileges to create <folder>. Skipping <file>.
TypeError: unsupported operand type(s) for |=: 'bool' and 'NoneType', exc_info: Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/app/.venv/lib/python3.14/site-packages/sidecar.py", line 158, in <module>
    main()
    ~~~~^^
  File "/app/.venv/lib/python3.14/site-packages/sidecar.py", line 146, in main
    list_resources(label, label_value, target_folder, init_request_url, request_method, request_payload,
    ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                   ns, folder_annotation, res, unique_filenames, script, enable_5xx,
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                   True, resource_name)
                   ^^^^^^^^^^^^^^^^^^^^
  File "/app/.venv/lib/python3.14/site-packages/resources.py", line 192, in list_resources
    files_changed = _process_secret(dest_folder, item, resource, unique_filenames, enable_5xx)
  File "/app/.venv/lib/python3.14/site-packages/resources.py", line 228, in _process_secret
    files_changed |= _iterate_data(
                     ~~~~~~~~~~~~~^
        secret.data,
        ^^^^^^^^^^^^
    ...<5 lines>...
        enable_5xx,
        ^^^^^^^^^^^
        is_removed)
        ^^^^^^^^^^^
  File "/app/.venv/lib/python3.14/site-packages/resources.py", line 323, in _iterate_data
    files_changed |= _update_file(
    ...<8 lines>...
        remove_files)
TypeError: unsupported operand type(s) for |=: 'bool' and 'NoneType'
```