### PR TITLE
Add the missing build dependencies for all platforms, not just ARMv7.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY        src/ /app/src/
 RUN if [ "$TARGETPLATFORM" = "linux/arm/v7" ]; then \
         apk add --no-cache gcc musl-dev g++ libffi-dev openssl-dev cargo; \
     else \
-        apk add --no-cache gcc; \
+        apk add --no-cache gcc musl-dev libffi-dev; \
     fi && \
     .venv/bin/pip install --no-cache-dir . && \
     find /app/.venv \( -type d -a -name test -o -name tests \) -o \( -type f -a -name '*.pyc' -o -name '*.pyo' \) -exec rm -rf '{}' \+


### PR DESCRIPTION
  This ensures that the build process works correctly on all target platforms.

  - include musl-dev and libffi-dev for all platforms:
    - musl-dev - C library headers and linker support
    - libffi-dev - FFI (Foreign Function Interface) development files