### PR TITLE
add riscv64 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,12 @@ RUN if [ "$TARGETPLATFORM" = "linux/riscv64" ] ||  ["$TARGETPLATFORM" = "linux/a
 
 
 FROM base
+ARG TARGETPLATFORM
+RUN if [ "$TARGETPLATFORM" = "linux/riscv64" ] ||  ["$TARGETPLATFORM" = "linux/arm/v7"]; then \
+        # fix for: 
+        # ImportError: Error loading shared library libgcc_s.so.1: No such file or directory (needed by /app/.venv/lib/python3.15/site-packages/cryptography/hazmat/bindings/_rust.abi3.so)
+        apk add --no-cache libgcc libstdc++; \
+    fi
 LABEL org.opencontainers.image.source=https://github.com/kiwigrid/k8s-sidecar
 LABEL org.opencontainers.image.description="K8s sidecar image to collect configmaps and secrets as files"
 LABEL org.opencontainers.image.licenses=MIT

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN python -m venv .venv && .venv/bin/pip install --no-cache-dir -U pip setuptoo
 COPY        pyproject.toml /app/
 COPY        src/ /app/src/
 # Install dependencies based on the target platform
-RUN if [ "$TARGETPLATFORM" = "linux/arm/v7" ]; then \
+RUN if [ "$TARGETPLATFORM" = "linux/riscv64" ] ||  ["$TARGETPLATFORM" = "linux/arm/v7"]; then \
         apk add --no-cache gcc musl-dev g++ libffi-dev openssl-dev cargo; \
     else \
         apk add --no-cache gcc musl-dev libffi-dev; \

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -3,7 +3,8 @@ target "k8s-sidecar" {
   platforms = [
     "linux/amd64",
     "linux/arm64",
-    "linux/arm/v7"
+    "linux/arm/v7",
+    "linux/riscv64"
   ]
   # Tags are dynamically defined in wokflows, so we leave this empty here
   tags = []


### PR DESCRIPTION
Hi, I am running a multi-architecture AMD/ARM64/RISCV64 Kubernetes cluster with Jenkins, among other things.

It uses your k8s-sidecar Docker image in the Helm Chart, but it does not have RISCV64 support yet.

I believe these are all the changes needed so that I no longer have to create my version:

```bash
git clone https://github.com/kiwigrid/k8s-sidecar.git
cd k8s-sidecar
git checkout 2.7.3
sed -i -e 's|linux/arm/v7|linux/riscv64|g' Dockerfile
docker buildx build . --platform linux/amd64,linux/arm64,linux/riscv64 --tag opvolger/k8s-sidecar:2.7.3  --push
```

and add values to the helm chart installation of jenkins

```yaml
controller:
  sidecars:
    configAutoReload:
      image:
        repository: opvolger/k8s-sidecar
```