### PR TITLE
Use ENTRYPOINT instead of CMD to allow CLI flags

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -269,6 +269,7 @@ jobs:
         run: |
           mkdir /tmp/sidecar
           mkdir /tmp/sidecar-5xx
+          mkdir /tmp/sidecar-basicauth-args
           echo "Downloading resource files from sidecar..."
           kubectl cp sidecar:/tmp/hello.world /tmp/sidecar/hello.world
           kubectl cp sidecar:/tmp/cm-kubelogo.png /tmp/sidecar/cm-kubelogo.png

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,4 +28,4 @@ ENV PATH="/app/.venv/bin:$PATH"
 # Use the nobody user's numeric UID/GID to satisfy MustRunAsNonRoot PodSecurityPolicies
 # https://kubernetes.io/docs/concepts/policy/pod-security-policy/#users-and-groups
 USER        65534:65534
-CMD         [ "python", "-u", "-m", "sidecar" ]
+ENTRYPOINT  [ "python", "-u", "-m", "sidecar" ]

--- a/README.md
+++ b/README.md
@@ -70,6 +70,15 @@ If the filename ends with `.url` suffix, the content will be processed as a URL 
 | `--req-username-file` | Path to file containing username to use for basic authentication for requests to `REQ_URL` and for `*.url` triggered requests. This overrides the `REQ_USERNAME` | false    | -       | string  |
 | `--req-password-file` | Path to file containing password to use for basic authentication for requests to `REQ_URL` and for `*.url` triggered requests. This overrides the `REQ_PASSWORD` | false    | -       | string  |
 
+```yaml
+containers:
+  - name: k8s-sidecar
+    image: ghcr.io/kiwigrid/k8s-sidecar:latest
+    args:
+      - --req-username-file=/path/to/username
+      - --req-password-file=/path/to/password
+```
+
 ## Configuration Environment Variables
 
 | name                       | description                                                                                                                                                                                                                                                                                                                         | required | default                                   | type    |

--- a/test/resources/sidecar.yaml
+++ b/test/resources/sidecar.yaml
@@ -436,7 +436,9 @@ spec:
   containers:
   - name: sidecar
     image: kiwigrid/k8s-sidecar:testing
-    command: [ "python" , "-u" , "-m", "sidecar" , "--req-username-file=/opt/creds/username" , "--req-password-file=/opt/creds/password"]
+    args:
+      - --req-username-file=/opt/creds/username
+      - --req-password-file=/opt/creds/password
     imagePullPolicy: IfNotPresent
     volumeMounts:
     - name: auth-creds


### PR DESCRIPTION
Using CMD doesn't allow to pass CLI flags like `--req-password-file`, ENTRYPOINT does :)

### CMD
```bash
$ docker run k8s-sidecar --req-password-file /vault/secrets/admin-password
docker: Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: exec: "--req-password-file": executable file not found in $PATH: unknown

Run 'docker run --help' for more information
```

### ENTRYPOINT
```bash
$ docker run k8s-sidecar --req-password-file /vault/secrets/admin-password
{"time": "2026-06-09T14:23:39.433191+00:00", "level": "INFO", "msg": "Starting collector"}
{"time": "2026-06-09T14:23:39.433793+00:00", "level": "INFO", "msg": "No folder annotation was provided, defaulting to k8s-sidecar-target-directory"}
{"time": "2026-06-09T14:23:39.433896+00:00", "level": "CRITICAL", "msg": "Should have added {LABEL} as environment variable! Exit"}
```