### PR TITLE
Add riscv64 and restore ppc64le image support #minor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,16 +8,19 @@ RUN python -m venv .venv && .venv/bin/pip install --no-cache-dir -U pip setuptoo
 COPY        pyproject.toml /app/
 COPY        src/ /app/src/
 # Install dependencies based on the target platform
-RUN if [ "$TARGETPLATFORM" = "linux/arm/v7" ]; then \
-        apk add --no-cache gcc musl-dev g++ libffi-dev openssl-dev cargo; \
-    else \
-        apk add --no-cache gcc musl-dev libffi-dev; \
-    fi && \
+RUN case "$TARGETPLATFORM" in \
+        "linux/arm/v7"|"linux/ppc64le"|"linux/riscv64") apk add --no-cache gcc musl-dev g++ libffi-dev openssl-dev cargo ;; \
+        *) apk add --no-cache gcc musl-dev libffi-dev ;; \
+    esac && \
     .venv/bin/pip install --no-cache-dir . && \
     find /app/.venv \( -type d -a -name test -o -name tests \) -o \( -type f -a -name '*.pyc' -o -name '*.pyo' \) -exec rm -rf '{}' \+
 
 
 FROM base
+ARG TARGETPLATFORM
+RUN case "$TARGETPLATFORM" in \
+        "linux/arm/v7"|"linux/ppc64le"|"linux/riscv64") apk add --no-cache libgcc libstdc++ ;; \
+    esac
 LABEL org.opencontainers.image.source=https://github.com/kiwigrid/k8s-sidecar
 LABEL org.opencontainers.image.description="K8s sidecar image to collect configmaps and secrets as files"
 LABEL org.opencontainers.image.licenses=MIT

--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@ Images are available at:
 - [quay.io/kiwigrid/k8s-sidecar](https://quay.io/repository/kiwigrid/k8s-sidecar)
 - [ghcr.io/kiwigrid/k8s-sidecar](https://github.com/orgs/kiwigrid/packages/container/package/k8s-sidecar)
 
-All are identical multi-arch images built for `amd64`, `arm64` and `arm/v7`.
+All are identical multi-arch images built for `amd64`, `arm64`, `arm/v7`, `ppc64le` and `riscv64`.
 
-## Dropped support for `ppc64le` and `s390x`
+## Dropped support for `s390x`
 
-With v2.x we have dropped support for the `ppc64le` and `s390x` architectures.
-If you still have a need for those architectures please get in touch.
+With v2.x we dropped support for the `ppc64le` and `s390x` architectures. Support for `ppc64le` has since been restored, while `s390x` remains unsupported.
+If you still have a need for `s390x`, please get in touch.
 A possible solution would be to setup a dedicated build job using a native runner instead of qemu.
 
 # Features
@@ -181,6 +181,7 @@ This workflow does **not** create tags, releases, or push images to registries.
   - `push` to `master` that touches:
     - `src/**`
     - `Dockerfile`
+    - `docker-bake.hcl`
 - **Versioning & tagging:**
   - Uses [`anothrNick/github-tag-action`](https://github.com/anothrNick/github-tag-action).
   - By default, each qualifying push bumps the **patch** version
@@ -204,7 +205,7 @@ This workflow does **not** create tags, releases, or push images to registries.
 
 This ensures that:
 
-- Only code changes in `src/**` or `Dockerfile` produce new images.
+- Only changes in `src/**`, `Dockerfile` or `docker-bake.hcl` produce new images.
 - Existing tags are not rebuilt and remain **immutable**.
 - CI-only or documentation-only changes do not trigger a release.
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -3,9 +3,11 @@ target "k8s-sidecar" {
   platforms = [
     "linux/amd64",
     "linux/arm64",
-    "linux/arm/v7"
+    "linux/arm/v7",
+    "linux/ppc64le",
+    "linux/riscv64"
   ]
-  # Tags are dynamically defined in wokflows, so we leave this empty here
+  # Tags are dynamically defined in workflows, so we leave this empty here
   tags = []
 }
 group "default" {


### PR DESCRIPTION
- add linux/riscv64 and linux/ppc64le to the multi-arch image build
- install required build and runtime libraries for native Python dependencies
- document the newly supported architectures
- update the documented release triggers

Validated full builds and runtime imports for riscv64 and ppc64le.