### PR TITLE
Update Python base image to version 3.15.0b2-alpine3.23

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.15.0b2-alpine3.22 AS base
+FROM python:3.15.0b2-alpine3.23 AS base
 
 FROM base AS builder
 # TARGETPLATFORM is automatically set by buildx (e.g., to "linux/arm/v7")


### PR DESCRIPTION
## Summary

It fixes https://nvd.nist.gov/vuln/detail/CVE-2026-45447

```
CID=$(docker create python:3.15.0b2-alpine3.23)

docker export $CID | tar -xf - -O lib/apk/db/installed 2>/dev/null | grep -A5 "P:libssl\|P:libcrypto"
P:libcrypto3
V:3.5.7-r0
A:aarch64
S:2282662
I:4961766
T:Crypto library from openssl
--
P:libssl3
V:3.5.7-r0
A:aarch64
S:370212
I:868240
T:SSL shared libraries
```