### PR TITLE
fix: fall back to IPv4 for health server when IPv6 is unavailable

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -202,6 +202,8 @@ jobs:
           wait_for_pod_ready "sidecar"
           wait_for_pod_ready "sidecar-healthcheck"
           wait_for_pod_log "sidecar-healthcheck" "Starting health server on port 8888"
+          wait_for_pod_ready "sidecar-healthcheck-ipv4"
+          wait_for_pod_log "sidecar-healthcheck-ipv4" "Starting health server on port 8888"
           wait_for_pod_ready "sidecar-basicauth-args"
           wait_for_pod_ready "sidecar-5xx"
           wait_for_pod_ready "sidecar-pythonscript"
@@ -252,6 +254,7 @@ jobs:
           mkdir /tmp/logs
           kubectl logs sidecar > /tmp/logs/sidecar.log
           kubectl logs sidecar-healthcheck > /tmp/logs/sidecar-healthcheck.log
+          kubectl logs sidecar-healthcheck-ipv4 > /tmp/logs/sidecar-healthcheck-ipv4.log
           kubectl logs sidecar-basicauth-args > /tmp/logs/sidecar-basicauth-args.log
           kubectl logs sidecar-5xx > /tmp/logs/sidecar-5xx.log
           kubectl logs sidecar-pythonscript > /tmp/logs/sidecar-pythonscript.log
@@ -382,6 +385,26 @@ jobs:
         run: |
           echo "--- Verifying health server response on IPv6 in pod sidecar-healthcheck ---"
           kubectl exec sidecar-healthcheck -- python -c "import urllib.request; res = urllib.request.urlopen('http://[::1]:8888/healthz'); print(res.read().decode())"
+      - name: Verify health server startup with HEALTH_HOST=0.0.0.0
+        shell: bash
+        run: |
+          source /tmp/sidecar_helpers.sh
+          echo "--- Verifying health server startup in pod sidecar-healthcheck-ipv4 ---"
+          check_log_contains "Starting health server on port 8888" /tmp/logs/sidecar-healthcheck-ipv4.log
+      - name: Verify health server response on IPv4 with HEALTH_HOST=0.0.0.0
+        shell: bash
+        run: |
+          echo "--- Verifying health server response on IPv4 in pod sidecar-healthcheck-ipv4 ---"
+          kubectl exec sidecar-healthcheck-ipv4 -- python -c "import urllib.request; res = urllib.request.urlopen('http://0.0.0.0:8888/healthz'); print(res.read().decode())"
+      - name: Verify health server rejects IPv6 with HEALTH_HOST=0.0.0.0
+        shell: bash
+        run: |
+          echo "--- Verifying health server rejects IPv6 in pod sidecar-healthcheck-ipv4 (HEALTH_HOST=0.0.0.0 forces AF_INET) ---"
+          if kubectl exec sidecar-healthcheck-ipv4 -- python -c "import urllib.request; urllib.request.urlopen('http://[::1]:8888/healthz', timeout=5)"; then
+            echo "Error: expected IPv6 access to fail when HEALTH_HOST=0.0.0.0 is set, but it succeeded"
+            exit 1
+          fi
+          echo "IPv6 access correctly rejected when HEALTH_HOST=0.0.0.0 is set"
       - name: Verify sidecar-basicauth-args pod file after initial sync
         shell: bash
         run: |

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -400,7 +400,7 @@ jobs:
         shell: bash
         run: |
           echo "--- Verifying health server rejects IPv6 in pod sidecar-healthcheck-ipv4 (HEALTH_HOST=0.0.0.0 forces AF_INET) ---"
-          if kubectl exec sidecar-healthcheck-ipv4 -- python -c "import urllib.request; urllib.request.urlopen('http://[::1]:8888/healthz', timeout=5)"; then
+          if kubectl exec sidecar-healthcheck-ipv4 -- python -c "import urllib.request; urllib.request.urlopen('http://[::1]:8888/healthz', timeout=5)" 2>/dev/null; then
             echo "Error: expected IPv6 access to fail when HEALTH_HOST=0.0.0.0 is set, but it succeeded"
             exit 1
           fi

--- a/README.md
+++ b/README.md
@@ -121,10 +121,11 @@ containers:
 | `LOG_TZ`                   | Set the log timezone. (LOCAL or UTC)                                                                                                                                                                                                                                                                                                | false    | `LOCAL`                                   | string  |
 | `LOG_CONFIG`               | Log configuration file path. If not configured, uses the default log config for backward compatibility support. When not configured `LOG_LEVEL, LOG_FORMAT and LOG_TZ` would be used. Refer to [Python logging](https://docs.python.org/3/library/logging.config.html) for log configuration. For sample configuration file  refer to file examples/example_logconfig.yaml | false    | -                                         | string  |
 | `HEALTH_PORT`              | The port for the health endpoint (`/healthz`).                                                                                                                                                                                                                                                                                                                             | false    | `8080`                                    | integer |
+| `HEALTH_HOST`              | The host/address the health endpoint binds to. If unset, the sidecar tries dual-stack IPv6 first and automatically falls back to IPv4 if IPv6 is unavailable (e.g. `ipv6.disable=1`, IPv4-only clusters). Set this to force a specific address family, e.g. `0.0.0.0` for IPv4-only or `::` for IPv6-only.                                                              | false    | -                                          | string  |
 
 ## Health Endpoint
 
-The sidecar provides a health endpoint at `/healthz` on port `8080` (or as configured by `HEALTH_PORT`) that can be used for Kubernetes readiness and liveness probes. The endpoint is compatible with both IPv4 and IPv6 (dual-stack).
+The sidecar provides a health endpoint at `/healthz` on port `8080` (or as configured by `HEALTH_PORT`) that can be used for Kubernetes readiness and liveness probes. By default, the endpoint is compatible with both IPv4 and IPv6 (dual-stack), automatically falling back to IPv4-only if IPv6 is unavailable. Use `HEALTH_HOST` to override the bind address explicitly.
 
 ### Readiness Probe
 

--- a/src/healthz.py
+++ b/src/healthz.py
@@ -1,3 +1,4 @@
+import ipaddress
 import logging
 import logging.config
 import os
@@ -106,6 +107,34 @@ def register_watcher_processes(processes: List[Thread]):
     global watcher_processes
     watcher_processes = processes
 
+def _create_health_http_server(health_port: int) -> ThreadingHTTPServer:
+    """
+    Create the health HTTP server, binding to HEALTH_HOST if set.
+
+    Without HEALTH_HOST, dual-stack IPv6 is attempted first and IPv4 is used
+    as a fallback for clusters/pods without IPv6 support (see #531, #605, #606).
+    """
+    logger = logging.getLogger("health_server")
+    health_host = os.getenv("HEALTH_HOST")
+
+    if health_host is not None:
+        try:
+            family = socket.AF_INET6 if ipaddress.ip_address(health_host).version == 6 else socket.AF_INET
+        except ValueError:
+            # Not an IP literal (e.g. a hostname); let the OS resolve it as IPv6/dual-stack.
+            family = socket.AF_INET6
+        ThreadingHTTPServer.address_family = family
+        return ThreadingHTTPServer((health_host, health_port), HealthHandler)
+
+    try:
+        ThreadingHTTPServer.address_family = socket.AF_INET6
+        return ThreadingHTTPServer(("", health_port), HealthHandler)
+    except OSError:
+        logger.warning("IPv6 not available, falling back to IPv4 for the health server")
+        ThreadingHTTPServer.address_family = socket.AF_INET
+        return ThreadingHTTPServer(("", health_port), HealthHandler)
+
+
 def start_health_server():
     """
     Start the lightweight health HTTP server in a background thread.
@@ -129,8 +158,7 @@ def start_health_server():
         logging.config.dictConfig(log_config)
 
         health_port = int(os.getenv("HEALTH_PORT", "8080"))
-        ThreadingHTTPServer.address_family = socket.AF_INET6
-        server = ThreadingHTTPServer(("", health_port), HealthHandler)
+        server = _create_health_http_server(health_port)
 
         logging.getLogger("health_server").info(
             "Starting health server on port %d", health_port

--- a/test/resources/sidecar.yaml
+++ b/test/resources/sidecar.yaml
@@ -141,6 +141,64 @@ spec:
 apiVersion: v1
 kind: Pod
 metadata:
+  name: sidecar-healthcheck-ipv4
+  namespace: default
+spec:
+  serviceAccountName: sample-acc
+  containers:
+  - name: sidecar
+    image: kiwigrid/k8s-sidecar:testing
+    volumeMounts:
+    - name: shared-volume
+      mountPath: /tmp/
+    - name: script-volume
+      mountPath: /opt/script.sh
+      subPath: script.sh
+    env:
+      - name: LABEL
+        value: "findme"
+      - name: FOLDER
+        value: /tmp/
+      - name: RESOURCE
+        value: both
+      - name: SCRIPT
+        value: "/opt/script.sh"
+      - name: REQ_USERNAME
+        value: "user1"
+      - name: REQ_PASSWORD
+        value: "abcdefghijklmnopqrstuvwxyz"
+      - name: REQ_BASIC_AUTH_ENCODING
+        # the python server we're using for the tests expects ascii encoding of basic auth credentials, hence we can't use non-ascii characters in the password or username
+        value: "ascii"
+      - name: LOG_LEVEL
+        value: "DEBUG"
+      - name: HEALTH_PORT
+        value: "8888"
+      - name: HEALTH_HOST
+        value: "0.0.0.0"
+    readinessProbe:
+      httpGet:
+        path: /healthz
+        port: 8888
+      initialDelaySeconds: 25
+      periodSeconds: 5
+    livenessProbe:
+      httpGet:
+        path: /healthz
+        port: 8888
+      initialDelaySeconds: 35
+      periodSeconds: 10
+  volumes:
+  - name: shared-volume
+    emptyDir: {}
+  - name: script-volume
+    configMap:
+      name: script-configmap
+      defaultMode: 0777
+---
+apiVersion: v1
+kind: Pod
+metadata:
   name: sidecar-pythonscript
   namespace: default
 spec:


### PR DESCRIPTION
The health server forced `ThreadingHTTPServer.address_family` to `AF_INET6` unconditionally, which crashes the health-server thread with OSError: [Errno 97] on pods/clusters without IPv6 support. Dual-stack IPv6 is now tried first and IPv4 is used as an automatic fallback. A new optional `HEALTH_HOST` env var lets users force a specific bind address/family explicitly.

Fixes #531, #605, #606

#patch