### PR TITLE
build: remove redundant argparse==1.4.0 dependency

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,7 @@ on:
       - 'src/**'
       - 'Dockerfile'
       - 'docker-bake.hcl'
+      - 'pyproject.toml'
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.15.0b2-alpine3.22@sha256:8374b202f092c233441f36b3018fd839c5c42d58b0a8ea479860f9ff2326d8cf AS base
 RUN apk add --no-cache \
-        libcrypto3=3.5.7-r0 \
-        libssl3=3.5.7-r0
+        libcrypto3=3.5.8-r0 \
+        libssl3=3.5.8-r0
 
 FROM base AS builder
 # TARGETPLATFORM is automatically set by buildx (e.g., to "linux/arm/v7")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,6 @@ dependencies = [
     "requests==2.33.1",
     "python-json-logger==4.1.0",
     "logfmter==0.0.12",
-    "argparse==1.4.0",
     "pyasn1==0.6.4",
 ]
 


### PR DESCRIPTION
argparse is stdlib since Python 3.2; this project already requires
>=3.12. The PyPI argparse package is an archived Python 2 backport
that only adds supply-chain scanner noise. #None