### PR TITLE
fix: use floor constraint for libcrypto3/libssl3 pin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.15.0b2-alpine3.22@sha256:8374b202f092c233441f36b3018fd839c5c42d58b0a8ea479860f9ff2326d8cf AS base
 RUN apk add --no-cache \
-        libcrypto3=3.5.8-r0 \
-        libssl3=3.5.8-r0
+        'libcrypto3>=3.5.7-r0' \
+        'libssl3>=3.5.7-r0'
 
 FROM base AS builder
 # TARGETPLATFORM is automatically set by buildx (e.g., to "linux/arm/v7")


### PR DESCRIPTION
## Summary
- Fixes the currently red `master` Release build (run 33158657062), broken since PR #622.
- `libcrypto3=3.5.8-r0` / `libssl3=3.5.8-r0` was an exact pin, but Alpine's per-architecture repos roll forward asynchronously: `amd64`/`arm64`/`armv7`/`ppc64le` already have `3.5.8-r0`, while `riscv64` was still on `3.5.7-r0` — making the exact multi-arch pin unresolvable on that platform.
- Switches to a `>=3.5.7-r0` floor constraint so every architecture resolves to its own newest available patch that still satisfies the CVE-2026-45447 fix, instead of requiring one identical exact version everywhere.

## Test plan
- [x] `docker build .` (amd64) succeeds and produces a working image (`python -m sidecar --help`)
- [x] Verified `apk add 'libcrypto3>=3.5.7-r0' 'libssl3>=3.5.7-r0'` resolves cleanly on `linux/riscv64` via QEMU emulation against the same base image digest (resolves to `3.5.7-r0`)
- [ ] CI Release build passes on all platforms (amd64, arm64, armv7, ppc64le, riscv64)