### PR TITLE
fix: detect a stalled watch by tracking K8s contact per watcher thread

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -7,6 +7,24 @@ on:
   - pull_request
   - workflow_dispatch
 jobs:
+  # Unit tests for the liveness signal (#621, #626). Standard library only, so
+  # this needs no test runner dependency and finishes in seconds; it runs
+  # independently of the image build. `pip install .` is only there to pull the
+  # runtime dependencies that src/ imports.
+  unit-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+      - name: Install runtime dependencies
+        run: pip install .
+      - name: Run unit tests
+        run: python -m unittest discover -s test/unit -t test/unit
+
   build:
     runs-on: ubuntu-latest
     steps:

--- a/src/healthz.py
+++ b/src/healthz.py
@@ -7,17 +7,25 @@ import threading
 from datetime import datetime, timedelta, timezone
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from threading import Thread
-from typing import List
+from typing import Dict, List, Optional
 
 from logger import get_log_config
 
 # Health state variables
 is_ready = False
-last_k8s_contact = datetime.now(timezone.utc)
 watcher_processes: List[Thread] = []
 
-# Settings
-K8S_CONTACT_THRESHOLD_SECONDS = 60  # tolerated delay before declaring not live
+# Last successful Kubernetes contact, tracked PER WATCHER THREAD (keyed by
+# thread ident). A single shared timestamp is not enough: with RESOURCE=both
+# there is one watcher per resource kind, and a healthy one would keep the
+# shared timestamp fresh while another sits on a stalled stream (see #621).
+watcher_heartbeats: Dict[int, datetime] = {}
+_heartbeat_lock = threading.Lock()
+
+# Tolerated delay before declaring not live. Overridden in
+# register_watcher_processes() based on how often watchers actually report in;
+# the default only applies until watchers are registered.
+K8S_CONTACT_THRESHOLD_SECONDS = 60
 
 
 class HealthCheckFilter(logging.Filter):
@@ -32,7 +40,7 @@ class HealthHandler(BaseHTTPRequestHandler):
     server_version = "HealthHTTP/1.0"
 
     def do_GET(self):
-        global is_ready, last_k8s_contact, watcher_processes
+        global is_ready, watcher_processes
 
         if self.path != "/healthz":
             self.send_response(404)
@@ -49,16 +57,16 @@ class HealthHandler(BaseHTTPRequestHandler):
         if not is_ready:
             status = 503
             body = "NOT READY"
-        # Liveness check (k8s contact)
-        elif (now - last_k8s_contact) > timedelta(
-                seconds=K8S_CONTACT_THRESHOLD_SECONDS
-        ):
-            status = 503
-            body = "NOT LIVE (K8s contact lost)"
-        # Liveness check (watcher processes)
+        # Liveness check (watcher threads still running)
         elif watcher_processes and not all(p.is_alive() for p in watcher_processes):
             status = 503
             body = "NOT LIVE (watcher thread died)"
+        # Liveness check (k8s contact, per watcher). This is what catches a
+        # watcher that is still alive but stuck in a stream that never returns
+        # -- the failure mode of #338/#621, which is_alive() cannot see.
+        elif _stale_watchers(now):
+            status = 503
+            body = "NOT LIVE (K8s contact lost)"
         else:
             status = 200
             body = "OK"
@@ -95,17 +103,57 @@ def mark_ready():
 
 def update_k8s_contact():
     """
-    Update the timestamp of the last successful Kubernetes contact.
-    """
-    global last_k8s_contact
-    last_k8s_contact = datetime.now(timezone.utc)
+    Record a successful Kubernetes contact for the CALLING watcher thread.
 
-def register_watcher_processes(processes: List[Thread]):
+    Must be called from the watcher thread itself -- the heartbeat is keyed by
+    threading.get_ident(). Calling it from the main thread would only refresh
+    an entry nothing looks at, which was the original defect (#621): the main
+    loop refreshed a single shared timestamp every 5s regardless of whether any
+    watcher had reached the API server, so the liveness check could never fail.
     """
-    Register the list of watcher threads to be monitored for liveness.
+    with _heartbeat_lock:
+        watcher_heartbeats[threading.get_ident()] = datetime.now(timezone.utc)
+
+
+def _stale_watchers(now: datetime) -> List[Thread]:
     """
-    global watcher_processes
+    Return the registered watcher threads whose last Kubernetes contact is older
+    than the tolerated threshold. Empty while no watchers are registered (e.g.
+    METHOD=LIST), so a one-shot run is never reported as not live.
+    """
+    threshold = timedelta(seconds=K8S_CONTACT_THRESHOLD_SECONDS)
+    with _heartbeat_lock:
+        return [
+            t for t in watcher_processes
+            if (now - watcher_heartbeats.get(t.ident, now)) > threshold
+        ]
+
+
+def register_watcher_processes(processes: List[Thread], heartbeat_interval: Optional[int] = None):
+    """
+    Register the watcher threads to be monitored for liveness and seed their
+    heartbeats, so the clock starts at registration rather than at first report.
+
+    heartbeat_interval is how often a healthy watcher is expected to report in
+    (WATCH_SERVER_TIMEOUT when watching, SLEEP_TIME when polling). The threshold
+    is derived as twice that, so the check never sits exactly on the reconnect
+    boundary and flaps. K8S_CONTACT_THRESHOLD_SECONDS in the environment
+    overrides the derived value.
+    """
+    global watcher_processes, K8S_CONTACT_THRESHOLD_SECONDS
     watcher_processes = processes
+
+    override = os.getenv("K8S_CONTACT_THRESHOLD_SECONDS")
+    if override:
+        K8S_CONTACT_THRESHOLD_SECONDS = int(override)
+    elif heartbeat_interval:
+        K8S_CONTACT_THRESHOLD_SECONDS = 2 * int(heartbeat_interval)
+
+    now = datetime.now(timezone.utc)
+    with _heartbeat_lock:
+        watcher_heartbeats.clear()
+        for thread in processes:
+            watcher_heartbeats[thread.ident] = now
 
 def _create_health_http_server(health_port: int) -> ThreadingHTTPServer:
     """

--- a/src/resources.py
+++ b/src/resources.py
@@ -448,11 +448,21 @@ def _watch_resource_loop(shutdown_event, mode, label, label_value, target_folder
                 list_resources(label, label_value, target_folder, request_url, request_method, request_payload,
                                namespace, folder_annotation, resource, unique_filenames, script, enable_5xx,
                                ignore_already_processed, resource_name, folder_per_namespace)
+                # A completed LIST is proof of contact for this watcher.
+                update_k8s_contact()
                 sleep(int(os.getenv("SLEEP_TIME", 60)))
             else:
                 _watch_resource_iterator(label, label_value, target_folder, request_url, request_method, request_payload,
                                          namespace, folder_annotation, resource, unique_filenames, script, enable_5xx,
                                          ignore_already_processed, folder_per_namespace)
+                # The iterator returns once the server closes the stream after
+                # WATCH_SERVER_TIMEOUT, so reaching this line proves the
+                # connection ran its full course. This is the heartbeat that
+                # keeps an IDLE cluster healthy -- the per-event stamp inside
+                # the iterator never fires when no resources change. A stalled
+                # stream never returns here, so the heartbeat ages out and
+                # /healthz reports 503 (#338, #621).
+                update_k8s_contact()
         except ApiException as e:
             if e.status != 500:
                 logger.error(f"ApiException when calling kubernetes: {e}\n")
@@ -472,6 +482,23 @@ def _watch_resource_loop(shutdown_event, mode, label, label_value, target_folder
     logger.info(f"Shutdown event received, stopping watcher for {namespace}/{resource}.")
 
 
+def heartbeat_interval(mode, namespace, resource_name):
+    """
+    How often a healthy watcher is expected to report a successful Kubernetes
+    contact. The liveness threshold in healthz is derived from this value.
+
+    The predicate has to match the branch taken in _watch_resource_loop()
+    exactly, not just `mode`: with RESOURCE_NAME set on a non-ALL namespace,
+    WATCH also runs the list-and-sleep path and therefore reports in at
+    SLEEP_TIME rather than at WATCH_SERVER_TIMEOUT. Deriving from `mode` alone
+    sizes the threshold against the wrong interval and flaps as soon as
+    SLEEP_TIME exceeds twice WATCH_SERVER_TIMEOUT.
+    """
+    if mode == "SLEEP" or (namespace != 'ALL' and resource_name):
+        return int(os.getenv("SLEEP_TIME", 60))
+    return int(WATCH_SERVER_TIMEOUT)
+
+
 def watch_for_changes(mode, label, label_value, target_folder, request_url, request_method, request_payload,
                       current_namespace, folder_annotation, resources, unique_filenames, script, enable_5xx,
                       ignore_already_processed, resource_name, folder_per_namespace):
@@ -482,11 +509,13 @@ def watch_for_changes(mode, label, label_value, target_folder, request_url, requ
                                          ignore_already_processed, resource_name, folder_per_namespace)
 
     procs_only = [p for p, ns, resource in processes]
-    register_watcher_processes(procs_only)
+    register_watcher_processes(procs_only, heartbeat_interval(mode, current_namespace, resource_name))
 
     while True:
-        # Update k8s contact timestamp to show the main process is alive and watchers are running
-        update_k8s_contact()
+        # NOTE: deliberately no update_k8s_contact() here. Stamping from this
+        # loop would only prove that the loop itself is running, which is
+        # always true while the container is up -- it made the liveness check
+        # unfalsifiable (#621). Watchers stamp for themselves.
         died = False
         for proc, ns, resource in processes:
             if not proc.is_alive():

--- a/test/unit/test_liveness.py
+++ b/test/unit/test_liveness.py
@@ -1,0 +1,163 @@
+"""
+Unit tests for the watcher liveness signal (#621, #626).
+
+Only the standard library is used, so these run with `python -m unittest
+discover -s test/unit` and need no cluster and no extra test dependency.
+
+Note on mocking: the stand-ins for `list_resources` and
+`_watch_resource_iterator` are built with `create_autospec`, so calling them
+with the wrong number of arguments raises TypeError just like the real
+function would. A permissive `lambda *a, **k` would swallow that and hide
+exactly the class of bug that #628 fixes.
+"""
+import os
+import sys
+import threading
+import unittest
+from datetime import datetime, timedelta, timezone
+from unittest.mock import create_autospec
+
+sys.argv = [sys.argv[0]]  # helpers.py parses sys.argv with argparse at import time
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+
+import healthz      # noqa: E402
+import resources    # noqa: E402
+
+
+def _live_thread(stop):
+    t = threading.Thread(target=stop.wait, daemon=True)
+    t.start()
+    return t
+
+
+class PerWatcherHeartbeatTest(unittest.TestCase):
+    """The liveness signal must be per watcher, not one shared timestamp."""
+
+    def setUp(self):
+        self.stop = threading.Event()
+        self.addCleanup(self.stop.set)
+        healthz.watcher_heartbeats.clear()
+        healthz.watcher_processes = []
+        healthz.K8S_CONTACT_THRESHOLD_SECONDS = 60
+
+    def test_healthy_watcher_does_not_mask_a_stalled_sibling(self):
+        """With RESOURCE=both there is one watcher per resource kind. A single
+        shared timestamp would let the healthy one keep the check green."""
+        a, b = _live_thread(self.stop), _live_thread(self.stop)
+        healthz.register_watcher_processes([a, b], heartbeat_interval=30)
+
+        # Only watcher A reports in; B is alive but stuck in a stalled stream.
+        healthz.watcher_heartbeats[a.ident] = datetime.now(timezone.utc)
+        healthz.watcher_heartbeats[b.ident] = datetime.now(timezone.utc) - timedelta(seconds=300)
+
+        stale = healthz._stale_watchers(datetime.now(timezone.utc))
+        self.assertEqual([b], stale)
+        self.assertTrue(b.is_alive(), "is_alive() stays True, which is why it cannot catch this")
+
+    def test_no_watchers_registered_is_never_stale(self):
+        """METHOD=LIST registers no watchers; a one-shot run must not report
+        itself as not live."""
+        self.assertEqual([], healthz._stale_watchers(datetime.now(timezone.utc)))
+
+    def test_threshold_is_derived_from_the_reporting_interval(self):
+        healthz.register_watcher_processes([_live_thread(self.stop)], heartbeat_interval=30)
+        self.assertEqual(60, healthz.K8S_CONTACT_THRESHOLD_SECONDS)
+
+    def test_environment_overrides_the_derived_threshold(self):
+        os.environ["K8S_CONTACT_THRESHOLD_SECONDS"] = "123"
+        self.addCleanup(os.environ.pop, "K8S_CONTACT_THRESHOLD_SECONDS", None)
+        healthz.register_watcher_processes([_live_thread(self.stop)], heartbeat_interval=30)
+        self.assertEqual(123, healthz.K8S_CONTACT_THRESHOLD_SECONDS)
+
+    def test_registration_seeds_heartbeats(self):
+        """The clock has to start at registration, otherwise a watcher that has
+        not reported yet looks stale on the very first probe."""
+        t = _live_thread(self.stop)
+        healthz.register_watcher_processes([t], heartbeat_interval=30)
+        self.assertIn(t.ident, healthz.watcher_heartbeats)
+        self.assertEqual([], healthz._stale_watchers(datetime.now(timezone.utc)))
+
+
+class WatchLoopHeartbeatTest(unittest.TestCase):
+    """Both branches of _watch_resource_loop() must record a heartbeat."""
+
+    LOOP_ARGS = dict(
+        label="l", label_value=None, target_folder="/tmp/does-not-matter",
+        request_url=None, request_method=None, request_payload=None,
+        folder_annotation=None, resource="configmap", unique_filenames=False,
+        script=None, enable_5xx=False, ignore_already_processed=False,
+    )
+
+    def _run_one_iteration(self, mode, namespace="ALL", resource_name=None):
+        stamped = []
+        shutdown = threading.Event()
+
+        # autospec: wrong argument counts raise, they do not get swallowed.
+        fake_list = create_autospec(resources.list_resources, side_effect=lambda *a, **k: shutdown.set())
+        fake_watch = create_autospec(resources._watch_resource_iterator, side_effect=lambda *a, **k: shutdown.set())
+
+        patches = {
+            "update_k8s_contact": lambda: stamped.append(True),
+            "_initialize_kubeclient_configuration": lambda: None,
+            "sleep": lambda _s: shutdown.set(),
+            "list_resources": fake_list,
+            "_watch_resource_iterator": fake_watch,
+        }
+        originals = {name: getattr(resources, name) for name in patches}
+        for name, value in patches.items():
+            setattr(resources, name, value)
+        self.addCleanup(lambda: [setattr(resources, n, v) for n, v in originals.items()])
+
+        a = self.LOOP_ARGS
+        resources._watch_resource_loop(
+            shutdown, mode, a["label"], a["label_value"], a["target_folder"],
+            a["request_url"], a["request_method"], a["request_payload"],
+            namespace, a["folder_annotation"], a["resource"], a["unique_filenames"],
+            a["script"], a["enable_5xx"], a["ignore_already_processed"],
+            resource_name, False,
+        )
+        return stamped
+
+    def test_sleep_branch_records_a_heartbeat(self):
+        self.assertTrue(self._run_one_iteration("SLEEP"))
+
+    def test_watch_branch_records_a_heartbeat(self):
+        """An idle cluster produces no events, so the per-event stamp never
+        fires. Without the stamp after a completed reconnect, a healthy sidecar
+        would age out and be restarted."""
+        self.assertTrue(self._run_one_iteration("WATCH"))
+
+    def test_watch_with_resource_name_takes_the_list_path_and_still_stamps(self):
+        self.assertTrue(self._run_one_iteration("WATCH", namespace="default", resource_name="cm-a"))
+
+
+class HeartbeatIntervalTest(unittest.TestCase):
+    """The interval must match the branch a watcher actually takes."""
+
+    def setUp(self):
+        os.environ["SLEEP_TIME"] = "90"
+        self.addCleanup(os.environ.pop, "SLEEP_TIME", None)
+
+    def test_sleep_mode_uses_sleep_time(self):
+        self.assertEqual(90, resources.heartbeat_interval("SLEEP", "ALL", None))
+
+    def test_plain_watch_uses_the_server_timeout(self):
+        self.assertEqual(int(resources.WATCH_SERVER_TIMEOUT),
+                         resources.heartbeat_interval("WATCH", "ALL", None))
+
+    def test_watch_with_resource_name_on_one_namespace_uses_sleep_time(self):
+        """This is the case the derivation used to get wrong: WATCH plus
+        RESOURCE_NAME on a single namespace runs the list-and-sleep path, so it
+        reports in at SLEEP_TIME. Sizing it against WATCH_SERVER_TIMEOUT flaps
+        once SLEEP_TIME exceeds twice that value."""
+        self.assertEqual(90, resources.heartbeat_interval("WATCH", "default", "cm-a"))
+
+    def test_watch_with_resource_name_on_all_namespaces_still_watches(self):
+        """RESOURCE_NAME only diverts to the list path when the namespace is
+        not ALL, so this one must stay on the watch interval."""
+        self.assertEqual(int(resources.WATCH_SERVER_TIMEOUT),
+                         resources.heartbeat_interval("WATCH", "ALL", "cm-a"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #621, and the condition originally reported in #338.

Thanks @ChristianGeie for verifying both root causes against master, and for the correction on threads vs. processes. The terminology in #621 was wrong, and it turns out to matter for the fix; see below.

## What was wrong

A watcher thread can block indefinitely inside `for event in stream:` when a watch stream stalls. The thread stays alive, so `is_alive()` reports healthy, and until now the contact timestamp did too, because `watch_for_changes()` refreshed a single shared `last_k8s_contact` every 5 seconds from the main loop, unconditionally. That only ever proved that the main loop was running, which is always true while the container is up. So `/healthz` answered `200 OK` while the sidecar had silently stopped delivering resources.

## What this changes

**1. The main loop no longer stamps.** Only watchers report their own contact.

**2. Watchers stamp on every completed watch reconnect** (the iterator returning proves the stream ran its full course) **and after every completed LIST in SLEEP mode.** The pre-existing per-event stamp is kept, but it is not sufficient on its own: an idle cluster produces no events, so without the reconnect stamp a perfectly healthy sidecar would age out and be declared not live.

**3. The threshold is derived from how often watchers actually report in:** `2 × WATCH_SERVER_TIMEOUT`, or `2 × SLEEP_TIME` when polling. It was previously hardcoded to 60, exactly equal to the default `WATCH_SERVER_TIMEOUT`, so once the check could fail at all it would have sat right on the reconnect boundary and flapped. `K8S_CONTACT_THRESHOLD_SECONDS` still overrides it, so anyone pinning the old value keeps it.

## One addition beyond the three points discussed in the issue

The heartbeat is now tracked **per watcher thread** (keyed by `threading.get_ident()`) rather than in one shared variable.

This is precisely where the threads-not-processes correction becomes load-bearing. With `RESOURCE=both` (the default, and what both reports ran) there is one watcher per resource kind, and they share the module global directly. A healthy watcher therefore keeps refreshing the shared timestamp while its sibling sits on a stalled stream, and the check still never fires. Moving the stamp out of the main loop alone would have fixed the reported symptom only when *every* watcher stalls at once, which is the lucky case, not the general one.

## Verification

I could not find an existing unit test layer to hang this off, since `test/` is the kind-based e2e setup. So I verified it by simulating the failure directly: two live watcher threads, one of which stops reporting contact while remaining alive, against a real health server.

| Variant | `/healthz` after threshold |
|---|---|
| before this change, main loop stamping | `200 OK`, the reported defect |
| before this change, watchers stamping (the three issue points only) | `200 OK`, healthy sibling masks the stalled one |
| after this change | `503 NOT LIVE (K8s contact lost)` |

`is_alive()` is `True` for the stalled watcher in all three runs, which is why the existing thread check cannot catch this.

A second check covers `resources.py` rather than `healthz.py`: it drives `_watch_resource_loop()` through one iteration in each mode with the API calls stubbed out, and asserts that a heartbeat is recorded in both the WATCH and the SLEEP branch, and that `watch_for_changes()` records none. I added it after the first version of this branch turned out to carry the comment describing the reconnect stamp without the call itself, which the health-server simulation could not see because it never runs `resources.py`.

Happy to fold those simulations into the repo as tests if you want unit tests introduced. It needs no cluster, only `threading` and the health server, but it would mean adding a test runner and a CI job, so I left that out of this PR rather than deciding it for you.

## Notes

- `METHOD=LIST` is unaffected: with no watchers registered, `_stale_watchers()` is empty and a one-shot run is never reported as not live.
- Behaviour on an idle cluster is now *better* defined than before: the reconnect stamp gives a real heartbeat where previously only the (unfalsifiable) main-loop stamp existed.
- The failure this addresses is invisible from inside the container by any other means we could find. For anyone hitting it before this ships, `METHOD=SLEEP` avoids the stall entirely, and log silence is the only external signal: a healthy sidecar logs once per reconnect, a stalled one logs nothing at all.
