### PR TITLE
fix: pass folder_per_namespace to list_resources() in the SLEEP/resource_name watch loop

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -358,7 +358,7 @@ jobs:
           }
           echo "Updating resources..."
           kubectl apply -f "test/resources/change_resources.yaml"
-          pods=("sidecar" "sidecar-5xx")
+          pods=("sidecar" "sidecar-5xx" "sidecar-sleep")
           resources=("sample-configmap" "sample-secret-binary" "absolute-configmap" "relative-configmap" "change-dir-configmap" "similar-configmap-secret" "url-configmap-500" "url-configmap-basic-auth" "sample-configmap")
           for p in ${pods[*]}; do
             for r in ${resources[*]}; do
@@ -386,6 +386,12 @@ jobs:
           ls /tmp/sidecar/script_result || echo "script_result missing"
 
           echo "All sidecar files after initial sync verified successfully."
+      - name: Verify sidecar-sleep files after update
+        shell: bash
+        run: |
+          source /tmp/sidecar_helpers.sh
+          echo "--- Verifying sidecar-sleep picks up updates via its LIST+sleep loop (METHOD=SLEEP) ---"
+          check_pod_file_exists sidecar-sleep /tmp/change-hello.world
       - name: Verify health server startup
         shell: bash
         run: |

--- a/src/resources.py
+++ b/src/resources.py
@@ -447,7 +447,7 @@ def _watch_resource_loop(shutdown_event, mode, label, label_value, target_folder
             if mode == "SLEEP" or (namespace != 'ALL' and resource_name):
                 list_resources(label, label_value, target_folder, request_url, request_method, request_payload,
                                namespace, folder_annotation, resource, unique_filenames, script, enable_5xx,
-                               ignore_already_processed, resource_name)
+                               ignore_already_processed, resource_name, folder_per_namespace)
                 sleep(int(os.getenv("SLEEP_TIME", 60)))
             else:
                 _watch_resource_iterator(label, label_value, target_folder, request_url, request_method, request_payload,


### PR DESCRIPTION
## What was wrong

`_watch_resource_loop()` in `src/resources.py` calls `list_resources()` from its `METHOD=SLEEP` / `RESOURCE_NAME`-on-a-non-`ALL`-namespace branch:

```python
if mode == "SLEEP" or (namespace != 'ALL' and resource_name):
    list_resources(label, label_value, target_folder, request_url, request_method, request_payload,
                   namespace, folder_annotation, resource, unique_filenames, script, enable_5xx,
                   ignore_already_processed, resource_name)
```

`list_resources()` gained a trailing `folder_per_namespace` parameter in #603 (`feat: add FOLDER_PER_NAMESPACE to organize output files by namespace`). This call site was not updated, so it now raises:

```
TypeError: list_resources() missing 1 required positional argument: 'folder_per_namespace'
```

on every single iteration. The broad `except Exception` in the surrounding loop catches it, logs "Received unknown exception", sleeps `ERROR_THROTTLE_SLEEP`, and retries — forever. In practice this means: **any sidecar running `METHOD=SLEEP`, or `METHOD=WATCH` with `RESOURCE_NAME` set and `NAMESPACE` not `ALL`, never syncs again after its initial list.** The initial sync in `sidecar.py`'s `main()` is unaffected (it already passes `folder_per_namespace` correctly), which is why this only shows up after the first update.

This was not caught by CI: `build_and_test.yaml` deploys a `sidecar-sleep` pod, but only asserts it becomes ready and logs its startup line — the "files reflect an update" checks after `change_resources.yaml` is applied only ever ran against the `sidecar` and `sidecar-5xx` pods (both `METHOD=WATCH`).

## What this changes

- `src/resources.py`: pass `folder_per_namespace` through to `list_resources()` at the missing call site.
- `.github/workflows/build_and_test.yaml`: add `sidecar-sleep` to the pods checked for propagating an update (log-based, alongside the existing `sidecar`/`sidecar-5xx` check), plus a dedicated step asserting `/tmp/change-hello.world` actually lands in the `sidecar-sleep` pod after `change_resources.yaml` is applied — so a regression here fails CI instead of shipping silently again.

## Notes

- Found while reviewing #626 (the watcher-heartbeat liveness fix for #621): that PR adds a heartbeat stamp right after this same `list_resources()` call, which would otherwise never be reached in `METHOD=SLEEP` — meaning affected sidecars would go from "silently stuck" to "livenessProbe failing and restart-looping" once #626 lands on top of this bug. #626 should rebase onto this once merged.